### PR TITLE
Download godot-lib and update build files to new name

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -24,6 +24,12 @@ jobs:
           distribution: 'adopt'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
+      - name: Download Godot Lib
+        run: |
+          cd aar
+          wget https://downloads.tuxfamily.org/godotengine/4.0/beta3/godot-lib.4.0.beta3.template_release.aar
+          mv godot-lib.4.0.beta3.template_release.aar godot-lib.template_release.aar
+          cd ..
       - name: Create Godot OpenXR loader AARs
         run: |
           cd aar

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+.vscode/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,3 +3,6 @@
 ## 1.0.0
 - First version
 - Added support for Meta Quest loader
+
+## 1.0.1
+- Changed to new naming convention for godot-lib for beta 3 compatibility

--- a/godotopenxrmeta/build.gradle
+++ b/godotopenxrmeta/build.gradle
@@ -39,7 +39,7 @@ android {
 dependencies {
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
 
-    compileOnly files('src/godot/godot-lib.release.aar')
+    compileOnly files('../godot-lib.template_release.aar')
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'


### PR DESCRIPTION
Changed to new beta 3 naming for godot-lib and instead of including this file in our repo, downloading official release from the Godot website.
We will need to keep this updated when newer versions come out.