### PR TITLE
Update Pico SDK v2.1.0

### DIFF
--- a/godotopenxrpico/src/main/jniLibs/arm64-v8a/README.md
+++ b/godotopenxrpico/src/main/jniLibs/arm64-v8a/README.md
@@ -1,4 +1,4 @@
-The Pico OpenXR loader binary is part of the [Pico OpenXR SDK](https://developer-global.pico-interactive.com/sdk?deviceId=1&platformId=3&itemId=11) v2.0.1 licensed under the "PICO IMMERSIVE PTE. LTD – SDK LICENSE TERMS" printed below. In communication with Godot developers, Pico explicitly clarified that the redistribution of the loader binary as part of the Godot export plugin and its repositories is permitted under these terms.
+The Pico OpenXR loader binary is part of the [Pico OpenXR SDK](https://developer-global.pico-interactive.com/sdk?deviceId=1&platformId=3&itemId=11) v2.1.0 licensed under the "PICO IMMERSIVE PTE. LTD – SDK LICENSE TERMS" printed below. In communication with Godot developers, Pico explicitly clarified that the redistribution of the loader binary as part of the Godot export plugin and its repositories is permitted under these terms.
 
 ----
 


### PR DESCRIPTION
This commit updates assets extracted from Pico's OpenXR SDK to the latest version available from Pico, v2.1.0.

Pico claims to mainly have worked on becoming more standard-compliant, [Changelog from the official download page](https://developer-global.pico-interactive.com/sdk?deviceId=1&platformId=3&itemId=11):

> Update:
> - Support OpenXR standard API 1.0.24
> - Migrate the original non-standard extensions of PICO to standard extensions
> 
> Known issues:
> - To use the new version of the OpenXR SDK, ROM version should be 5.2.x and later (For Neo3, a supported version is expected to be released after 2022/12/15).
> - Some PICO non-standard extensions have been removed. See the migration instructions in the development documentation for details.