### PR TITLE
KHR loader: Remove activity tag, move to main Godot repo

### DIFF
--- a/godotopenxrkhr/README.md
+++ b/godotopenxrkhr/README.md
@@ -1,4 +1,25 @@
-Binaries taken from the Official OpenXR working group repo at:
+# Godot OpenXR KHR Android loader
 
+Binaries taken from the Official OpenXR working group repo at:
 https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/release-1.0.26/openxr_loader_for_android-1.0.26.aar
 
+# AndroidManifest changes
+
+Activities that use OpenXR should add the IMMERSIVE_HMD category tag to their intent-filter
+
+```xml
+<category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
+```
+
+for example:
+
+```xml
+    <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+        <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
+    </intent-filter>
+```
+
+Details on this category tag can be found here:
+https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#android-runtime-category

--- a/godotopenxrkhr/src/main/AndroidManifest.xml
+++ b/godotopenxrkhr/src/main/AndroidManifest.xml
@@ -9,15 +9,6 @@
         <meta-data
             android:name="org.godotengine.plugin.v1.GodotOpenXRKHR"
             android:value="org.godotengine.openxrloaders.khr.GodotOpenXRKHR" />
-
-        <activity android:name="com.godot.game.GodotApp" android:exported="true" tools:ignore="MissingClass">
-            <intent-filter>
-                <!-- Mark this activity as using OpenXR. -->
-                <!-- action tag is here to make sure this intent filter is loaded by AOSP. -->
-                <action android:name="org.khronos.openxr.action.MAIN" />
-                <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
-            </intent-filter>
-        </activity>
     </application>
 
 </manifest>

--- a/godotopenxrkhr/src/main/java/org/godotengine/openxrloaders/godotopenxrkhr/GodotOpenXRKHR.java
+++ b/godotopenxrkhr/src/main/java/org/godotengine/openxrloaders/godotopenxrkhr/GodotOpenXRKHR.java
@@ -3,7 +3,22 @@ package org.godotengine.openxrloaders.khr;
 import org.godotengine.godot.Godot;
 import org.godotengine.godot.plugin.GodotPlugin;
 
-
+/**
+ * \brief GodotOpenXRKHR is the OpenXR KHR loader plugin for Godot.
+ *
+ * When using OpenXR for your application on Android make sure that
+ * the IMMERSIVE_HMD category is added to your activities intent-filter.
+ *
+ *   <intent-filter>
+ *       <action android:name="android.intent.action.MAIN" />
+ *       <category android:name="android.intent.category.LAUNCHER" />
+ *       <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
+ *   </intent-filter>
+ *
+ * more details can be found here:
+ * https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#android-runtime-category
+ *
+ */
 public class GodotOpenXRKHR extends GodotPlugin {
 
     public GodotOpenXRKHR(Godot godot) {


### PR DESCRIPTION
Remove the intent-filter here in favor of placing this category directly into the main godot repo

https://github.com/godotengine/godot/pull/72533