### PR TITLE
Add Lynx loader support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,3 +5,4 @@
 - Added support for Meta Quest loader
 - Added support for Pico loader
 - Added support for Khronos loader (Magic Leap 2, HTC, etc.)
+- Added support for Lynx loader

--- a/GodotOpenXRLynx.gdap
+++ b/GodotOpenXRLynx.gdap
@@ -1,0 +1,7 @@
+[config]
+
+name="GodotOpenXRLynx"
+binary_type="local"
+binary="godotopenxrlynx/godotopenxrlynx-release.aar"
+
+[dependencies]

--- a/godotopenxrlynx/README.md
+++ b/godotopenxrlynx/README.md
@@ -1,0 +1,28 @@
+# Godot OpenXR Lynx Android loader
+
+Binaries taken from Lynx at:
+https://portal.lynx-r.com/downloads/item/1/download/latest
+
+# AndroidManifest changes
+
+Add this to your manifest to enable OpenXR and Ultraleap's hand tracking:
+
+```
+<uses-feature android:name="android.hardware.vr.headtracking" android:required="true" android:version="1"/>
+<uses-permission android:name="org.khronos.openxr.permission.OPENXR"/>
+
+<queries>
+    <intent>
+        <action android:name="org.khronos.openxr.OpenXRRuntimeService"/>
+    </intent>
+    <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" />
+    <package android:name="com.ultraleap.tracking.service"/>
+    <package android:name="com.ultraleap.openxr.api_layer"/>
+</queries>
+```
+
+And add this to the `application` block in your manifest to enable hand tracking:
+
+```
+<meta-data android:name="handtracking" android:value="1" />
+```

--- a/godotopenxrlynx/README.md
+++ b/godotopenxrlynx/README.md
@@ -2,27 +2,3 @@
 
 Binaries taken from Lynx at:
 https://portal.lynx-r.com/downloads/item/1/download/latest
-
-# AndroidManifest changes
-
-Add this to your manifest to enable OpenXR and Ultraleap's hand tracking:
-
-```
-<uses-feature android:name="android.hardware.vr.headtracking" android:required="true" android:version="1"/>
-<uses-permission android:name="org.khronos.openxr.permission.OPENXR"/>
-
-<queries>
-    <intent>
-        <action android:name="org.khronos.openxr.OpenXRRuntimeService"/>
-    </intent>
-    <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" />
-    <package android:name="com.ultraleap.tracking.service"/>
-    <package android:name="com.ultraleap.openxr.api_layer"/>
-</queries>
-```
-
-And add this to the `application` block in your manifest to enable hand tracking:
-
-```
-<meta-data android:name="handtracking" android:value="1" />
-```

--- a/godotopenxrlynx/build.gradle
+++ b/godotopenxrlynx/build.gradle
@@ -1,0 +1,40 @@
+plugins {
+    id 'com.android.library'
+}
+
+android {
+    compileSdk versions.compileSdk
+
+    defaultConfig {
+        minSdk versions.minSdk
+        targetSdk versions.targetSdk
+        versionCode versions.versionCode
+        versionName versions.versionName
+
+        ndk {
+            abiFilters 'arm64-v8a', 'armeabi-v7a',  'x86',  'x86_64'
+        }
+    }
+
+    namespace = "org.godotengine.openxrloaders.khr"
+
+    buildTypes {
+        debug {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    packagingOptions {
+        doNotStrip '**/*.so'
+    }
+
+    compileOptions {
+        sourceCompatibility versions.javaVersion
+        targetCompatibility versions.javaVersion
+    }
+}
+
+dependencies {
+    compileOnly "io.github.m4gr3d:godot:$versions.godotLibVersion"
+}

--- a/godotopenxrlynx/build.gradle
+++ b/godotopenxrlynx/build.gradle
@@ -12,11 +12,11 @@ android {
         versionName versions.versionName
 
         ndk {
-            abiFilters 'arm64-v8a', 'armeabi-v7a',  'x86',  'x86_64'
+            abiFilters 'arm64-v8a'
         }
     }
 
-    namespace = "org.godotengine.openxrloaders.khr"
+    namespace = "org.godotengine.openxrloaders.lynx"
 
     buildTypes {
         debug {

--- a/godotopenxrlynx/proguard-rules.pro
+++ b/godotopenxrlynx/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/godotopenxrlynx/src/main/AndroidManifest.xml
+++ b/godotopenxrlynx/src/main/AndroidManifest.xml
@@ -4,11 +4,25 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="org.khronos.openxr.permission.OPENXR_SYSTEM" />
+    
+    <uses-feature android:name="android.hardware.vr.headtracking" android:required="true" android:version="1"/>
+    <uses-permission android:name="org.khronos.openxr.permission.OPENXR"/>
+
+    <queries>
+        <intent>
+            <action android:name="org.khronos.openxr.OpenXRRuntimeService"/>
+        </intent>
+        <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" />
+        <package android:name="com.ultraleap.tracking.service"/>
+        <package android:name="com.ultraleap.openxr.api_layer"/>
+    </queries>
 
     <application>
         <meta-data
             android:name="org.godotengine.plugin.v1.GodotOpenXRLynx"
             android:value="org.godotengine.openxrloaders.khr.GodotOpenXRLynx" />
+
+        <meta-data android:name="handtracking" android:value="1" />
     </application>
 
 </manifest>

--- a/godotopenxrlynx/src/main/AndroidManifest.xml
+++ b/godotopenxrlynx/src/main/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.godotengine.openxrloaders.lynx"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="org.khronos.openxr.permission.OPENXR_SYSTEM" />
+
+    <application>
+        <meta-data
+            android:name="org.godotengine.plugin.v1.GodotOpenXRLynx"
+            android:value="org.godotengine.openxrloaders.khr.GodotOpenXRLynx" />
+    </application>
+
+</manifest>

--- a/godotopenxrlynx/src/main/java/org/godotengine/openxrloaders/godotopenxrlynx/GodotOpenXRLynx.java
+++ b/godotopenxrlynx/src/main/java/org/godotengine/openxrloaders/godotopenxrlynx/GodotOpenXRLynx.java
@@ -1,0 +1,19 @@
+package org.godotengine.openxrloaders.lynx;
+
+import org.godotengine.godot.Godot;
+import org.godotengine.godot.plugin.GodotPlugin;
+
+/**
+ * \brief GodotOpenXRLynx is the OpenXR Lynx loader plugin for Godot.
+ */
+public class GodotOpenXRLynx extends GodotPlugin {
+
+    public GodotOpenXRLynx(Godot godot) {
+        super(godot);
+    }
+
+    @Override
+    public String getPluginName() {
+        return "GodotOpenXRLynx";
+    }
+}

--- a/godotopenxrlynx/src/main/jniLibs/arm64-v8a/abi.json
+++ b/godotopenxrlynx/src/main/jniLibs/arm64-v8a/abi.json
@@ -1,0 +1,6 @@
+{
+  "abi": "arm64-v8a",
+  "api": 24,
+  "ndk": 21,
+  "stl": "c++_shared"
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,4 +6,4 @@ dependencyResolutionManagement {
     }
 }
 rootProject.name = "GodotOpenXRLoaders"
-include ':godotopenxrmeta', ':godotopenxrpico', ':godotopenxrkhr'
+include ':godotopenxrmeta', ':godotopenxrpico', ':godotopenxrkhr', ':godotopenxrlynx'


### PR DESCRIPTION
This MR adds support for the Lynx loader and the Lynx R-1 headset.

Tested features:
* Head tracking :heavy_check_mark: 
* Hand tracking :heavy_check_mark: 
* I have some issues with displaying the hand model and OpenGL, need to investigate
* Vulkan kind of works but is upside down and spam the console with errors

This MR is currently missing the LICENSE file.
Merging this MR should close #22 