### PR TITLE
Adding missing focusaware entry to meta manifest

### DIFF
--- a/godotopenxrmeta/src/main/AndroidManifest.xml
+++ b/godotopenxrmeta/src/main/AndroidManifest.xml
@@ -15,6 +15,10 @@
         <meta-data
             android:name="com.oculus.supportedDevices"
             android:value="quest|quest2|questpro" />
+
+        <meta-data
+            android:name="com.oculus.vr.focusaware"
+            android:value="true" />
     </application>
 
 </manifest>


### PR DESCRIPTION
This PR adds a missing entry in the AndroidManifest.xml for the meta loader, that is required when uploading an application to either App Lab or the main Meta Quest store.