### PR TITLE
Fix workflows to include new actions

### DIFF
--- a/.github/workflows/build-addon-on-push.yml
+++ b/.github/workflows/build-addon-on-push.yml
@@ -13,11 +13,11 @@ jobs:
     # this is why we checkout into aar and build into asset
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: aar
       - name: Setup java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: 'adopt'
@@ -40,7 +40,7 @@ jobs:
           cp aar/godotopenxrpico/src/main/jniLibs/arm64-v8a/README.md asset/addons/godotopenxr/export/pico/LICENSE.md
           cp aar/godotopenxrkhr/LICENSE asset/addons/godotopenxr/export/khr/LICENSE
       - name: Create Godot OpenXR loader addon artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: GodotOpenXRLoadersAddon
           path: |
@@ -56,6 +56,8 @@ jobs:
           artifacts: "godotopenxrloadersaddon.zip"
           omitNameDuringUpdate: true
           omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
           token: ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 

--- a/.github/workflows/mavencentral-publish.yml
+++ b/.github/workflows/mavencentral-publish.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: adopt
           java-version: 11


### PR DESCRIPTION
This PR updates the workflows to use the new v3 actions and adds a few more flags to the release so our draft status doesn't get updated accidentally.