### PR TITLE
Add Meta configs for the eye gaze interaction extension

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 - Update to the new Godot 4.2 Android plugin packaging format
 - Update the plugin to Godot v2 Android plugin
 - Update to the Godot 4.2 Android library
+- Add warning when multiple loaders are selected
 
 ## 1.1.0
 - Update Meta OpenXR loader to version 54

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Update the plugin to Godot v2 Android plugin
 - Update to the Godot 4.2 Android library
 - Add warning when multiple loaders are selected
+- Add configs for the OpenXR Eye gaze interaction extension
 
 ## 1.1.0
 - Update Meta OpenXR loader to version 54

--- a/demo/addons/godotopenxr/.export/globals.gd
+++ b/demo/addons/godotopenxr/.export/globals.gd
@@ -1,5 +1,6 @@
 @tool
 
+# Set of supported vendors
 const META_VENDOR_NAME = "meta"
 const PICO_VENDOR_NAME = "pico"
 const LYNX_VENDOR_NAME = "lynx"
@@ -11,3 +12,6 @@ const VENDORS_LIST = [
 	LYNX_VENDOR_NAME,
 	KHRONOS_VENDOR_NAME,
 	]
+
+# Set of custom feature tags supported by the plugin
+const EYE_GAZE_INTERACTION_FEATURE = "XR_EXT_eye_gaze_interaction"

--- a/demo/addons/godotopenxr/.export/globals.gd
+++ b/demo/addons/godotopenxr/.export/globals.gd
@@ -1,0 +1,13 @@
+@tool
+
+const META_VENDOR_NAME = "meta"
+const PICO_VENDOR_NAME = "pico"
+const LYNX_VENDOR_NAME = "lynx"
+const KHRONOS_VENDOR_NAME = "khr"
+
+const VENDORS_LIST = [
+	META_VENDOR_NAME, 
+	PICO_VENDOR_NAME,
+	LYNX_VENDOR_NAME,
+	KHRONOS_VENDOR_NAME,
+	]

--- a/demo/addons/godotopenxr/.export/godot_openxr_editor_export_plugin.gd
+++ b/demo/addons/godotopenxr/.export/godot_openxr_editor_export_plugin.gd
@@ -1,6 +1,8 @@
 @tool
 class_name GodotOpenXREditorExportPlugin extends EditorExportPlugin
 
+var globals = preload("globals.gd")
+
 const OPENXR_MODE_VALUE = 1
 	
 var _vendor: String
@@ -26,14 +28,14 @@ func _get_android_maven_central_dependency() -> String:
 	return "org.godotengine:godot-openxr-loaders-" + _vendor + ":" + _plugin_version
 
 
-func _get_vendor_toggle_option_name() -> String:
-	return "xr_features/enable_" + _vendor + "_plugin"
+func _get_vendor_toggle_option_name(vendor_name: String = _vendor) -> String:
+	return "xr_features/enable_" + vendor_name + "_plugin"
 
 
-func _get_vendor_toggle_option() -> Dictionary:
+func _get_vendor_toggle_option(vendor_name: String = _vendor) -> Dictionary:
 	var toggle_option = {
 		"option": {
-			"name": _get_vendor_toggle_option_name(),
+			"name": _get_vendor_toggle_option_name(vendor_name),
 			"class_name": "",
 			"type": TYPE_BOOL,
 			"hint": PROPERTY_HINT_NONE,
@@ -69,7 +71,12 @@ func _get_export_option_warning(platform, option) -> String:
 	if not(_is_openxr_enabled()) and _get_bool_option(option):
 		return "\"Enable " + _vendor.capitalize() + " Plugin\" requires \"XR Mode\" to be \"OpenXR\".\n"
 	
-	return ""		
+	if _is_vendor_plugin_enabled():
+		for vendor_name in globals.VENDORS_LIST:
+			if (vendor_name != _vendor) and _is_vendor_plugin_enabled(vendor_name):
+				return "\"Disable " + _vendor.capitalize() + " Plugin before enabling another. Multiple plugins are not supported!\""
+	
+	return ""
 
 
 func _supports_platform(platform) -> bool:
@@ -92,8 +99,8 @@ func _get_int_option(option: String, default_value: int) -> int:
 	return default_value
 
 
-func _is_vendor_plugin_enabled() -> bool:
-	return _get_bool_option(_get_vendor_toggle_option_name())
+func _is_vendor_plugin_enabled(vendor_name: String = _vendor) -> bool:
+	return _get_bool_option(_get_vendor_toggle_option_name(vendor_name))
 	
 
 func _is_android_aar_file_available(debug: bool) -> bool:

--- a/demo/addons/godotopenxr/.export/godot_openxr_editor_plugin.gd
+++ b/demo/addons/godotopenxr/.export/godot_openxr_editor_plugin.gd
@@ -1,6 +1,8 @@
 @tool
 extends EditorPlugin
 
+var globals = preload("globals.gd")
+
 # A class member to hold the export plugin during its lifecycle.
 var meta_export_plugin : EditorExportPlugin
 var pico_export_plugin : EditorExportPlugin
@@ -12,10 +14,10 @@ func _enter_tree():
 	var plugin_version = get_plugin_version()
 	
 	# Initializing the export plugins
-	meta_export_plugin = preload("meta/godot_openxr_meta_editor_export_plugin.gd").new("meta", plugin_version)
-	pico_export_plugin = preload("pico/godot_openxr_pico_editor_export_plugin.gd").new("pico", plugin_version)
-	lynx_export_plugin = preload("lynx/godot_openxr_lynx_editor_export_plugin.gd").new("lynx", plugin_version)
-	khr_export_plugin = preload("khr/godot_openxr_khr_editor_export_plugin.gd").new("khr", plugin_version)
+	meta_export_plugin = preload("meta/godot_openxr_meta_editor_export_plugin.gd").new(globals.META_VENDOR_NAME, plugin_version)
+	pico_export_plugin = preload("pico/godot_openxr_pico_editor_export_plugin.gd").new(globals.PICO_VENDOR_NAME, plugin_version)
+	lynx_export_plugin = preload("lynx/godot_openxr_lynx_editor_export_plugin.gd").new(globals.LYNX_VENDOR_NAME, plugin_version)
+	khr_export_plugin = preload("khr/godot_openxr_khr_editor_export_plugin.gd").new(globals.KHRONOS_VENDOR_NAME, plugin_version)
 	
 	add_export_plugin(meta_export_plugin)
 	add_export_plugin(pico_export_plugin)

--- a/demo/export_presets.cfg
+++ b/demo/export_presets.cfg
@@ -35,6 +35,7 @@ package/app_category=2
 package/retain_data_on_uninstall=false
 package/exclude_from_recents=false
 package/show_in_android_tv=false
+package/show_in_app_library=true
 package/show_as_launcher_app=false
 launcher_icons/main_192x192=""
 launcher_icons/adaptive_foreground_432x432=""

--- a/demo/export_presets.cfg
+++ b/demo/export_presets.cfg
@@ -206,3 +206,4 @@ meta_xr_features/passthrough=1
 xr_features/enable_pico_plugin=false
 xr_features/enable_lynx_plugin=false
 xr_features/enable_khr_plugin=false
+meta_xr_features/eye_tracking=1

--- a/demo/main.gd
+++ b/demo/main.gd
@@ -1,9 +1,10 @@
 extends Node3D
 
+var xr_interface : XRInterface = null
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	var xr_interface : XRInterface = XRServer.find_interface("OpenXR")
+	xr_interface = XRServer.find_interface("OpenXR")
 	if xr_interface and xr_interface.is_initialized():
 		var vp: Viewport = get_viewport()
 		vp.use_xr = true

--- a/demo/main.tscn
+++ b/demo/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=3 uid="uid://cqsodpswgup8w"]
+[gd_scene load_steps=10 format=3 uid="uid://cqsodpswgup8w"]
 
 [ext_resource type="Script" path="res://main.gd" id="1_fsva1"]
 
@@ -20,7 +20,14 @@ size = Vector3(0.1, 0.1, 0.1)
 [sub_resource type="BoxMesh" id="BoxMesh_ey3x4"]
 size = Vector3(0.1, 0.1, 0.1)
 
+[sub_resource type="SphereMesh" id="SphereMesh_5gcab"]
+radius = 0.025
+height = 0.05
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_k604q"]
+
 [sub_resource type="PlaneMesh" id="PlaneMesh_mjcgt"]
+material = SubResource("StandardMaterial3D_k604q")
 size = Vector2(10, 10)
 
 [node name="Main" type="Node3D"]
@@ -39,7 +46,7 @@ shadow_enabled = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.352791, 0)
 
 [node name="LeftHand" type="XRController3D" parent="XROrigin3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.460909, 0, -0.241118)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.460909, 0.388594, -0.241118)
 tracker = &"left_hand"
 pose = &"aim"
 
@@ -47,11 +54,19 @@ pose = &"aim"
 mesh = SubResource("BoxMesh_3kt6b")
 
 [node name="RightHand" type="XRController3D" parent="XROrigin3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.478861, 0, -0.241097)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.478861, 0.468292, -0.241097)
 tracker = &"right_hand"
 
-[node name="MeshInstance3D" type="MeshInstance3D" parent="XROrigin3D/RightHand"]
+[node name="RightHandMesh" type="MeshInstance3D" parent="XROrigin3D/RightHand"]
 mesh = SubResource("BoxMesh_ey3x4")
+
+[node name="EyeGaze" type="XRController3D" parent="XROrigin3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.977669, 0)
+tracker = &"/user/eyes_ext"
+
+[node name="EyeGazeMesh" type="MeshInstance3D" parent="XROrigin3D/EyeGaze"]
+transform = Transform3D(1, 0, 0, 0, -0.0133513, 0.999911, 0, -0.999911, -0.0133513, 0, 0, -1.18886)
+mesh = SubResource("SphereMesh_5gcab")
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="."]
 mesh = SubResource("PlaneMesh_mjcgt")

--- a/demo/openxr_action_map.tres
+++ b/demo/openxr_action_map.tres
@@ -1,4 +1,4 @@
-[gd_resource type="OpenXRActionMap" load_steps=197 format=3 uid="uid://b1wdu77pwks8y"]
+[gd_resource type="OpenXRActionMap" load_steps=199 format=3 uid="uid://b1wdu77pwks8y"]
 
 [sub_resource type="OpenXRAction" id="OpenXRAction_6v1ja"]
 resource_name = "trigger"
@@ -115,7 +115,7 @@ toplevel_paths = PackedStringArray("/user/hand/left", "/user/hand/right")
 resource_name = "default_pose"
 localized_name = "Default pose"
 action_type = 3
-toplevel_paths = PackedStringArray("/user/hand/left", "/user/hand/right", "/user/vive_tracker_htcx/role/left_foot", "/user/vive_tracker_htcx/role/right_foot", "/user/vive_tracker_htcx/role/left_shoulder", "/user/vive_tracker_htcx/role/right_shoulder", "/user/vive_tracker_htcx/role/left_elbow", "/user/vive_tracker_htcx/role/right_elbow", "/user/vive_tracker_htcx/role/left_knee", "/user/vive_tracker_htcx/role/right_knee", "/user/vive_tracker_htcx/role/waist", "/user/vive_tracker_htcx/role/chest", "/user/vive_tracker_htcx/role/camera", "/user/vive_tracker_htcx/role/keyboard")
+toplevel_paths = PackedStringArray("/user/hand/left", "/user/hand/right", "/user/vive_tracker_htcx/role/left_foot", "/user/vive_tracker_htcx/role/right_foot", "/user/vive_tracker_htcx/role/left_shoulder", "/user/vive_tracker_htcx/role/right_shoulder", "/user/vive_tracker_htcx/role/left_elbow", "/user/vive_tracker_htcx/role/right_elbow", "/user/vive_tracker_htcx/role/left_knee", "/user/vive_tracker_htcx/role/right_knee", "/user/vive_tracker_htcx/role/waist", "/user/vive_tracker_htcx/role/chest", "/user/vive_tracker_htcx/role/camera", "/user/vive_tracker_htcx/role/keyboard", "/user/eyes_ext")
 
 [sub_resource type="OpenXRAction" id="OpenXRAction_1vol5"]
 resource_name = "aim_pose"
@@ -455,7 +455,7 @@ action = SubResource("OpenXRAction_0kk6l")
 paths = PackedStringArray("/user/hand/left/output/haptic", "/user/hand/right/output/haptic")
 
 [sub_resource type="OpenXRInteractionProfile" id="OpenXRInteractionProfile_ert82"]
-interaction_profile_path = "/interaction_profiles/pico/neo3_controller"
+interaction_profile_path = "/interaction_profiles/bytedance/pico_neo3_controller"
 bindings = [SubResource("OpenXRIPBinding_jwljs"), SubResource("OpenXRIPBinding_ajdja"), SubResource("OpenXRIPBinding_tla6d"), SubResource("OpenXRIPBinding_377i1"), SubResource("OpenXRIPBinding_xa4wm"), SubResource("OpenXRIPBinding_7xuhj"), SubResource("OpenXRIPBinding_03t7v"), SubResource("OpenXRIPBinding_b08bq"), SubResource("OpenXRIPBinding_fxhob"), SubResource("OpenXRIPBinding_661oy"), SubResource("OpenXRIPBinding_vsv5g"), SubResource("OpenXRIPBinding_bxu5n"), SubResource("OpenXRIPBinding_xer3x"), SubResource("OpenXRIPBinding_urrdv"), SubResource("OpenXRIPBinding_e1sbn"), SubResource("OpenXRIPBinding_vmo5c"), SubResource("OpenXRIPBinding_lytd7"), SubResource("OpenXRIPBinding_feotl"), SubResource("OpenXRIPBinding_fxu5d")]
 
 [sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_w77tt"]
@@ -830,6 +830,14 @@ paths = PackedStringArray("/user/vive_tracker_htcx/role/left_foot/output/haptic"
 interaction_profile_path = "/interaction_profiles/htc/vive_tracker_htcx"
 bindings = [SubResource("OpenXRIPBinding_vke8d"), SubResource("OpenXRIPBinding_3o4hq")]
 
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_73bb6"]
+action = SubResource("OpenXRAction_vk7pf")
+paths = PackedStringArray("/user/eyes_ext/input/gaze_ext/pose")
+
+[sub_resource type="OpenXRInteractionProfile" id="OpenXRInteractionProfile_07fna"]
+interaction_profile_path = "/interaction_profiles/ext/eye_gaze_interaction"
+bindings = [SubResource("OpenXRIPBinding_73bb6")]
+
 [resource]
 action_sets = [SubResource("OpenXRActionSet_kd2ms")]
-interaction_profiles = [SubResource("OpenXRInteractionProfile_kitsa"), SubResource("OpenXRInteractionProfile_uoohe"), SubResource("OpenXRInteractionProfile_k2llo"), SubResource("OpenXRInteractionProfile_2masb"), SubResource("OpenXRInteractionProfile_ert82"), SubResource("OpenXRInteractionProfile_aq5p3"), SubResource("OpenXRInteractionProfile_4petf"), SubResource("OpenXRInteractionProfile_sd46l"), SubResource("OpenXRInteractionProfile_prh4s"), SubResource("OpenXRInteractionProfile_kk5vf"), SubResource("OpenXRInteractionProfile_wxdsn")]
+interaction_profiles = [SubResource("OpenXRInteractionProfile_kitsa"), SubResource("OpenXRInteractionProfile_uoohe"), SubResource("OpenXRInteractionProfile_k2llo"), SubResource("OpenXRInteractionProfile_2masb"), SubResource("OpenXRInteractionProfile_ert82"), SubResource("OpenXRInteractionProfile_aq5p3"), SubResource("OpenXRInteractionProfile_4petf"), SubResource("OpenXRInteractionProfile_sd46l"), SubResource("OpenXRInteractionProfile_prh4s"), SubResource("OpenXRInteractionProfile_kk5vf"), SubResource("OpenXRInteractionProfile_wxdsn"), SubResource("OpenXRInteractionProfile_07fna")]

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -28,4 +28,5 @@ textures/vram_compression/import_etc2_astc=true
 [xr]
 
 openxr/enabled=true
+openxr/extensions/eye_gaze_interaction=true
 shaders/enabled=true

--- a/godotopenxrmeta/src/main/java/org/godotengine/openxrloaders/meta/GodotOpenXRMeta.java
+++ b/godotopenxrmeta/src/main/java/org/godotengine/openxrloaders/meta/GodotOpenXRMeta.java
@@ -17,4 +17,19 @@ public class GodotOpenXRMeta extends GodotPlugin {
         return "GodotOpenXRMeta";
     }
 
+    @Override
+    public boolean supportsFeature(String featureTag) {
+        if ("PERMISSION_XR_EXT_eye_gaze_interaction".equals(featureTag)) {
+            String[] grantedPermissions = getGodot().getGrantedPermissions();
+            if (grantedPermissions != null) {
+                for (String permission : grantedPermissions) {
+                    if ("com.oculus.permission.EYE_TRACKING".equals(permission)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
 }


### PR DESCRIPTION
The first commit is a small change to address and fix https://github.com/GodotVR/godot_openxr_loaders/issues/46

The second commit contains the majority of the changes and is the counterpart to https://github.com/godotengine/godot/pull/82614:
- Adds the necessary config option to enable eye tracking for Meta devices
- Defines `XR_EXT_eye_gaze_interaction` as a feature tag to set when eye tracking is enabled
  - On mobile xr devices, this feature tag is used to gate the eye gaze interaction extension
- Adds the necessary Meta permissions when eye tracking is enabled
- Updates the demo project to showcase eye tracking (tested on Quest Pro device)
- Updates Meta's `GodotPlugin` instance to return `true` for the `PERMISSION_XR_EXT_eye_gaze_interaction` feature tag when the necessary permissions are granted.

