### PR TITLE
[2.x] Code cleanup for the export logic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Change history for the Godot OpenXR loaders asset
 
 ## 2.0.4
+- Fix misc crash when reloading project on Godot 4.3
 - Fix issue with only the first permission being requested
 
 ## 2.0.3

--- a/godotopenxrkhronos/src/main/cpp/export/khronos_export_plugin.cpp
+++ b/godotopenxrkhronos/src/main/cpp/export/khronos_export_plugin.cpp
@@ -35,7 +35,7 @@ void KhronosEditorPlugin::_bind_methods() {}
 
 void KhronosEditorPlugin::_enter_tree() {
 	// Initialize the editor export plugin
-	khronos_export_plugin = memnew(KhronosEditorExportPlugin);
+	khronos_export_plugin.instantiate();
 	add_export_plugin(khronos_export_plugin);
 }
 
@@ -43,8 +43,7 @@ void KhronosEditorPlugin::_exit_tree() {
 	// Clean up the editor export plugin
 	remove_export_plugin(khronos_export_plugin);
 
-	memfree(khronos_export_plugin);
-	khronos_export_plugin = nullptr;
+	khronos_export_plugin.unref();
 }
 
 KhronosEditorExportPlugin::KhronosEditorExportPlugin() {

--- a/godotopenxrkhronos/src/main/cpp/export/khronos_export_plugin.h
+++ b/godotopenxrkhronos/src/main/cpp/export/khronos_export_plugin.h
@@ -58,5 +58,5 @@ protected:
 	static void _bind_methods();
 
 private:
-	KhronosEditorExportPlugin *khronos_export_plugin = nullptr;
+	Ref<KhronosEditorExportPlugin> khronos_export_plugin;
 };

--- a/godotopenxrlynx/src/main/cpp/export/lynx_export_plugin.cpp
+++ b/godotopenxrlynx/src/main/cpp/export/lynx_export_plugin.cpp
@@ -35,7 +35,7 @@ void LynxEditorPlugin::_bind_methods() {}
 
 void LynxEditorPlugin::_enter_tree() {
 	// Initialize the editor export plugin
-	lynx_export_plugin = memnew(OpenXREditorExportPlugin);
+	lynx_export_plugin.instantiate();
 	lynx_export_plugin->set_vendor_name(LYNX_VENDOR_NAME);
 	add_export_plugin(lynx_export_plugin);
 }
@@ -44,6 +44,5 @@ void LynxEditorPlugin::_exit_tree() {
 	// Clean up the editor export plugin
 	remove_export_plugin(lynx_export_plugin);
 
-	memfree(lynx_export_plugin);
-	lynx_export_plugin = nullptr;
+	lynx_export_plugin.unref();
 }

--- a/godotopenxrlynx/src/main/cpp/export/lynx_export_plugin.h
+++ b/godotopenxrlynx/src/main/cpp/export/lynx_export_plugin.h
@@ -46,5 +46,5 @@ protected:
 	static void _bind_methods();
 
 private:
-	OpenXREditorExportPlugin *lynx_export_plugin = nullptr;
+	Ref<OpenXREditorExportPlugin> lynx_export_plugin;
 };

--- a/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.cpp
+++ b/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.cpp
@@ -37,7 +37,7 @@ void MetaEditorPlugin::_bind_methods() {}
 
 void MetaEditorPlugin::_enter_tree() {
 	// Initialize the editor export plugin
-	meta_export_plugin = memnew(MetaEditorExportPlugin);
+	meta_export_plugin.instantiate();
 	add_export_plugin(meta_export_plugin);
 }
 
@@ -45,8 +45,7 @@ void MetaEditorPlugin::_exit_tree() {
 	// Clean up the editor export plugin
 	remove_export_plugin(meta_export_plugin);
 
-	memfree(meta_export_plugin);
-	meta_export_plugin = nullptr;
+	meta_export_plugin.unref();
 }
 
 MetaEditorExportPlugin::MetaEditorExportPlugin() {

--- a/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.h
+++ b/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.h
@@ -101,6 +101,5 @@ protected:
 	static void _bind_methods();
 
 private:
-	MetaEditorExportPlugin *meta_export_plugin = nullptr;
-
+	Ref<MetaEditorExportPlugin> meta_export_plugin;
 };

--- a/godotopenxrpico/src/main/cpp/export/pico_export_plugin.cpp
+++ b/godotopenxrpico/src/main/cpp/export/pico_export_plugin.cpp
@@ -35,7 +35,7 @@ void PicoEditorPlugin::_bind_methods() {}
 
 void PicoEditorPlugin::_enter_tree() {
 	// Initialize the editor export plugin
-	pico_export_plugin = memnew(OpenXREditorExportPlugin);
+	pico_export_plugin.instantiate();
 	pico_export_plugin->set_vendor_name(PICO_VENDOR_NAME);
 	add_export_plugin(pico_export_plugin);
 }
@@ -44,6 +44,5 @@ void PicoEditorPlugin::_exit_tree() {
 	// Clean up the editor export plugin
 	remove_export_plugin(pico_export_plugin);
 
-	memfree(pico_export_plugin);
-	pico_export_plugin = nullptr;
+	pico_export_plugin.unref();
 }

--- a/godotopenxrpico/src/main/cpp/export/pico_export_plugin.h
+++ b/godotopenxrpico/src/main/cpp/export/pico_export_plugin.h
@@ -46,5 +46,5 @@ protected:
 	static void _bind_methods();
 
 private:
-	OpenXREditorExportPlugin *pico_export_plugin = nullptr;
+	Ref<OpenXREditorExportPlugin> pico_export_plugin;
 };


### PR DESCRIPTION
Update the export logic so that export plugin objects are handed through references instead of using `memnew` and `memfree`

(cherry picked from https://github.com/GodotVR/godot_openxr_vendors/pull/80 commit e946c3a7c4d4cf82ebb7825ca83cca5ee33b4d64)

Fixes https://github.com/GodotVR/godot_openxr_vendors/issues/67 for the 2.x branch