### PR TITLE
Avoid casting errors for floats when precision=double

### DIFF
--- a/plugin/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
@@ -438,7 +438,11 @@ XrGeometryInstanceFB OpenXRFbPassthroughExtensionWrapper::create_geometry_instan
 	vertices.resize(vertex_array.size());
 	for (int j = 0; j < vertex_array.size(); j++) {
 		Vector3 vertex = vertex_array[j];
-		vertices[j] = { vertex.x, vertex.y, vertex.z };
+		vertices[j] = {
+			static_cast<float>(vertex.x),
+			static_cast<float>(vertex.y),
+			static_cast<float>(vertex.z)
+		};
 	}
 
 	Array index_array = surface_arrays[Mesh::ARRAY_INDEX];
@@ -472,10 +476,23 @@ XrGeometryInstanceFB OpenXRFbPassthroughExtensionWrapper::create_geometry_instan
 	Quaternion quat = transform.basis.get_rotation_quaternion();
 	Vector3 scale = transform.basis.get_scale();
 
-	XrQuaternionf xr_orientation = { quat.x, quat.y, quat.z, quat.w };
-	XrVector3f xr_position = { transform.origin.x, transform.origin.y, transform.origin.z };
+	XrQuaternionf xr_orientation = {
+		static_cast<float>(quat.x),
+		static_cast<float>(quat.y),
+		static_cast<float>(quat.z),
+		static_cast<float>(quat.w)
+	};
+	XrVector3f xr_position = {
+		static_cast<float>(transform.origin.x),
+		static_cast<float>(transform.origin.y),
+		static_cast<float>(transform.origin.z)
+	};
 	XrPosef xr_pose = { xr_orientation, xr_position };
-	XrVector3f xr_scale = { scale.x, scale.y, scale.z };
+	XrVector3f xr_scale = {
+		static_cast<float>(scale.x),
+		static_cast<float>(scale.y),
+		static_cast<float>(scale.z)
+	};
 
 	XrGeometryInstanceFB geometry_instance = XR_NULL_HANDLE;
 	XrGeometryInstanceCreateInfoFB geometry_instance_info = {
@@ -504,10 +521,23 @@ void OpenXRFbPassthroughExtensionWrapper::set_geometry_instance_transform(XrGeom
 	Quaternion quat = transform.basis.get_rotation_quaternion();
 	Vector3 scale = transform.basis.get_scale();
 
-	XrQuaternionf xr_orientation = { quat.x, quat.y, quat.z, quat.w };
-	XrVector3f xr_position = { transform.origin.x, transform.origin.y, transform.origin.z };
+	XrQuaternionf xr_orientation = {
+		static_cast<float>(quat.x),
+		static_cast<float>(quat.y),
+		static_cast<float>(quat.z),
+		static_cast<float>(quat.w)
+	};
+	XrVector3f xr_position = {
+		static_cast<float>(transform.origin.x),
+		static_cast<float>(transform.origin.y),
+		static_cast<float>(transform.origin.z)
+	};
 	XrPosef xr_pose = { xr_orientation, xr_position };
-	XrVector3f xr_scale = { scale.x, scale.y, scale.z };
+	XrVector3f xr_scale = {
+		static_cast<float>(scale.x),
+		static_cast<float>(scale.y),
+		static_cast<float>(scale.z)
+	};
 
 	XrGeometryInstanceTransformFB xr_transform = {
 		XR_TYPE_GEOMETRY_INSTANCE_TRANSFORM_FB, // type

--- a/plugin/src/main/cpp/extensions/openxr_fb_spatial_entity_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_spatial_entity_extension_wrapper.cpp
@@ -166,8 +166,13 @@ bool OpenXRFbSpatialEntityExtensionWrapper::create_spatial_anchor(const Transfor
 	Quaternion quat = Quaternion(p_transform.basis);
 	Vector3 pos = p_transform.origin;
 	XrPosef pose = {
-		{ quat.x, quat.y, quat.z, quat.w }, // orientation
-		{ pos.x, pos.y, pos.z }, // position
+		{ static_cast<float>(quat.x),
+				static_cast<float>(quat.y),
+				static_cast<float>(quat.z),
+				static_cast<float>(quat.w) }, // orientation
+		{ static_cast<float>(pos.x),
+				static_cast<float>(pos.y),
+				static_cast<float>(pos.z) } // position
 	};
 
 	XrSpatialAnchorCreateInfoFB info = {


### PR DESCRIPTION
Fix narrowing conversion errors in OpenXR plugin with explicit float casts

Errors similar to:

```c++
Compiling shared plugin/src/main/cpp/extensions/openxr_fb_spatial_entity_extension_wrapper.cpp ...
Compiling shared plugin/src/main/cpp/extensions/openxr_fb_android_surface_swapchain_create_extension_wrapper.cpp ...
plugin/src/main/cpp/extensions/openxr_fb_spatial_entity_extension_wrapper.cpp:169:5: error: non-constant-expression cannot be narrowed from type 'real_t' (aka 'double') to 'float' in initializer list [-Wc++11-narrowing]
                { quat.x, quat.y, quat.z, quat.w }, // orientation
                  ^~~~~~
plugin/src/main/cpp/extensions/openxr_fb_spatial_entity_extension_wrapper.cpp:169:5: note: insert an explicit cast to silence this issue
                { quat.x, quat.y, quat.z, quat.w }, // orientation
                  ^~~~~~
                  static_cast<float>( )
plugin/src/main/cpp/extensions/openxr_fb_spatial_entity_extension_wrapper.cpp:169:13: error: non-constant-expression cannot be narrowed from type 'real_t' (aka 'double') to 'float' in initializer list [-Wc++11-narrowing]
                { quat.x, quat.y, quat.z, quat.w }, // orientation
                          ^~~~~~
plugin/src/main/cpp/extensions/openxr_fb_spatial_entity_extension_wrapper.cpp:169:13: note: insert an explicit cast to silence this issue
                { quat.x, quat.y, quat.z, quat.w }, // orientation
                          ^~~~~~
                          static_cast<float>( )
plugin/src/main/cpp/extensions/openxr_fb_spatial_entity_extension_wrapper.cpp:169:21: error: non-constant-expression cannot be narrowed from type 'real_t' (aka 'double') to 'float' in initializer list [-Wc++11-narrowing]
                { quat.x, quat.y, quat.z, quat.w }, // orientation
                                  ^~~~~~
plugin/src/main/cpp/extensions/openxr_fb_spatial_entity_extension_wrapper.cpp:169:21: note: insert an explicit cast to silence this issue
                { quat.x, quat.y, quat.z, quat.w }, // orientation
                                  ^~~~~~
                                  static_cast<float>( )
plugin/src/main/cpp/extensions/openxr_fb_spatial_entity_extension_wrapper.cpp:169:29: error: non-constant-expression cannot be narrowed from type 'real_t' (aka 'double') to 'float' in initializer list [-Wc++11-narrowing]
                { quat.x, quat.y, quat.z, quat.w }, // orientation
                                          ^~~~~~
plugin/src/main/cpp/extensions/openxr_fb_spatial_entity_extension_wrapper.cpp:169:29: note: insert an explicit cast to silence this issue
                { quat.x, quat.y, quat.z, quat.w }, // orientation
                                          ^~~~~~
                                          static_cast<float>( )
```
