### PR TITLE
Add `workflow_dispatch` to the "MavenCentral Publish" workflow to allow manually running it

### DIFF
--- a/.github/workflows/mavencentral-publish.yml
+++ b/.github/workflows/mavencentral-publish.yml
@@ -5,6 +5,7 @@ on:
   release:
     # We'll run this workflow when a new GitHub release is created
     types: [published]
+  workflow_dispatch: {}
 
 jobs:
   publish:


### PR DESCRIPTION
This will add a "Run workflow" button within the GitHub UI that we can use to manually run the "MavenCentral Publish" workflow, in the case where GitHub forgets to run it for us (which happened with the 3.1.2 release for some reason).