### PR TITLE
Fix composition layer next chains

### DIFF
--- a/plugin/src/main/cpp/extensions/openxr_fb_composition_layer_alpha_blend_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_composition_layer_alpha_blend_extension_wrapper.cpp
@@ -183,6 +183,7 @@ uint64_t OpenXRFbCompositionLayerAlphaBlendExtensionWrapper::_set_viewport_compo
 		} break;
 	}
 
+	alpha_blend->next = p_next_pointer;
 	return reinterpret_cast<uint64_t>(alpha_blend);
 }
 

--- a/plugin/src/main/cpp/extensions/openxr_fb_composition_layer_depth_test_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_composition_layer_depth_test_extension_wrapper.cpp
@@ -90,6 +90,7 @@ uint64_t OpenXRFbCompositionLayerDepthTestExtensionWrapper::_set_viewport_compos
 	}
 
 	XrCompositionLayerDepthTestFB *depth_test = layer_structs.getptr(layer);
+	depth_test->next = p_next_pointer;
 	return reinterpret_cast<uint64_t>(depth_test);
 }
 

--- a/plugin/src/main/cpp/extensions/openxr_fb_composition_layer_image_layout_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_composition_layer_image_layout_extension_wrapper.cpp
@@ -82,7 +82,7 @@ uint64_t OpenXRFbCompositionLayerImageLayoutExtensionWrapper::_set_viewport_comp
 	if (!layer_structs.has(layer)) {
 		layer_structs[layer] = {
 			XR_TYPE_COMPOSITION_LAYER_IMAGE_LAYOUT_FB, // type
-			nullptr, // next
+			p_next_pointer, // next
 		};
 	}
 

--- a/plugin/src/main/cpp/extensions/openxr_fb_composition_layer_secure_content_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_composition_layer_secure_content_extension_wrapper.cpp
@@ -102,6 +102,7 @@ uint64_t OpenXRFbCompositionLayerSecureContentExtensionWrapper::_set_viewport_co
 		} break;
 	};
 
+	secure_content->next = p_next_pointer;
 	return reinterpret_cast<uint64_t>(secure_content);
 }
 

--- a/plugin/src/main/cpp/extensions/openxr_fb_composition_layer_settings_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_composition_layer_settings_extension_wrapper.cpp
@@ -141,6 +141,7 @@ uint64_t OpenXRFbCompositionLayerSettingsExtensionWrapper::_set_viewport_composi
 		return reinterpret_cast<uint64_t>(p_next_pointer);
 	}
 
+	settings->next = p_next_pointer;
 	return reinterpret_cast<uint64_t>(settings);
 }
 


### PR DESCRIPTION
Some composition layer structs are not always setting next pointers properly, this fixes that.