### PR TITLE
Make REC709 default for XR_FB_color_space

### DIFF
--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -455,10 +455,10 @@ void add_plugin_project_settings() {
 	{
 		String starting_color_space = "xr/openxr/extensions/meta/color_space/starting_color_space";
 		if (!project_settings->has_setting(starting_color_space)) {
-			project_settings->set_setting(starting_color_space, 0);
+			project_settings->set_setting(starting_color_space, 3);
 		}
 
-		project_settings->set_initial_value(starting_color_space, 0);
+		project_settings->set_initial_value(starting_color_space, 3);
 		project_settings->set_as_basic(starting_color_space, false);
 		Dictionary property_info;
 		property_info["name"] = starting_color_space;


### PR DESCRIPTION
This PR builds on top of #305.

Per discussion at the last XR meeting, the XR_FB_color_space implementation will initially use the runtime default color space in 4.x of the vendor plugin. When we move to 5.0 though, the default option will be updated to Rec. 709 and the warnings encouraging devs to use it will be removed.

This PR will remain as a draft until the XR_FB_color_space implementation is merged and until we begin merging changes for plugin version 5.0