### PR TITLE
Implement additional Meta body tracking extensions

### DIFF
--- a/doc_classes/OpenXRFbBodyTrackingExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbBodyTrackingExtensionWrapper.xml
@@ -8,4 +8,77 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="get_body_tracking_calibration_state">
+			<return type="int" enum="OpenXRFbBodyTrackingExtensionWrapper.BodyTrackingCalibrationState" />
+			<description>
+				Returns the body tracking calibration state.
+			</description>
+		</method>
+		<method name="get_body_tracking_fidelity_status">
+			<return type="int" enum="OpenXRFbBodyTrackingExtensionWrapper.BodyTrackingFidelity" />
+			<description>
+				Returns the body tracking fidelity status.
+			</description>
+		</method>
+		<method name="is_body_tracking_fidelity_supported">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the body tracking fidelity extension is supported.
+			</description>
+		</method>
+		<method name="is_body_tracking_height_override_supported">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if height override from the body tracking calibration extension is supported.
+			</description>
+		</method>
+		<method name="is_full_body_tracking_supported">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the body tracking full body extension is supported.
+			</description>
+		</method>
+		<method name="request_body_tracking_fidelity">
+			<return type="void" />
+			<param index="0" name="fidelity" type="int" enum="OpenXRFbBodyTrackingExtensionWrapper.BodyTrackingFidelity" />
+			<description>
+				Request that the OpenXR runtime use a specified body tracking fidelity.
+			</description>
+		</method>
+		<method name="reset_body_tracking_calibration">
+			<return type="void" />
+			<description>
+				Reset the body tracking calibration state.
+			</description>
+		</method>
+		<method name="suggest_body_tracking_height_override">
+			<return type="void" />
+			<param index="0" name="body_height" type="float" />
+			<description>
+				Suggest a height override in meters for body tracking calibration to the OpenXR runtime.
+				[b]Note:[/b] this value must be within the range of 0.5 and 3.0 meters.
+			</description>
+		</method>
+	</methods>
+	<constants>
+		<constant name="BODY_TRACKING_FIDELITY_UNKNOWN" value="0" enum="BodyTrackingFidelity">
+			Unknown body tracking fidelity.
+		</constant>
+		<constant name="BODY_TRACKING_FIDELITY_LOW" value="1" enum="BodyTrackingFidelity">
+			Low fidelity body tracking.
+		</constant>
+		<constant name="BODY_TRACKING_FIDELITY_HIGH" value="2" enum="BodyTrackingFidelity">
+			High fidelity body tracking.
+		</constant>
+		<constant name="BODY_TRACKING_CALIBRATION_STATE_VALID" value="0" enum="BodyTrackingCalibrationState">
+			Valid body tracking calibration state.
+		</constant>
+		<constant name="BODY_TRACKING_CALIBRATION_STATE_CALIBRATING" value="1" enum="BodyTrackingCalibrationState">
+			Calibrating body tracking calibration state.
+		</constant>
+		<constant name="BODY_TRACKING_CALIBRATION_STATE_INVALID" value="2" enum="BodyTrackingCalibrationState">
+			Invalid body tracking calibration state.
+		</constant>
+	</constants>
 </class>

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_body_tracking_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_body_tracking_extension_wrapper.h
@@ -30,6 +30,12 @@
 #ifndef OPENXR_FB_BODY_TRACKING_EXTENSION_WRAPPER_H
 #define OPENXR_FB_BODY_TRACKING_EXTENSION_WRAPPER_H
 
+// @todo GH Issue 304: Remove check for meta headers when feature becomes part of OpenXR spec.
+#ifdef META_HEADERS_ENABLED
+#include <meta_openxr_preview/meta_body_tracking_calibration.h>
+#include <meta_openxr_preview/meta_body_tracking_fidelity.h>
+#endif
+
 #include <openxr/openxr.h>
 #include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
 #include <godot_cpp/classes/xr_body_tracker.hpp>
@@ -95,13 +101,114 @@ private:
 	bool xr_body_tracker_registered = false;
 
 	// OpenXR system properties struct for XR_FB_body_tracking.
-	XrSystemBodyTrackingPropertiesFB system_body_tracking_properties;
+	XrSystemBodyTrackingPropertiesFB system_body_tracking_properties = {
+		XR_TYPE_SYSTEM_BODY_TRACKING_PROPERTIES_FB, // type
+		nullptr, // next
+		false, // supportsBodyTracking
+	};
 
 	// XR_FB_body_tracking handle.
 	XrBodyTrackerFB body_tracker = XR_NULL_HANDLE;
 
 	// Godot XRBodyTracker instance.
 	Ref<XRBodyTracker> xr_body_tracker;
+
+	// META_body_tracking_full_body extension.
+public:
+	bool is_full_body_tracking_supported();
+
+private:
+	bool meta_body_tracking_full_body_ext = false;
+
+	XrSystemPropertiesBodyTrackingFullBodyMETA system_body_tracking_full_body_properties{
+		XR_TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_FULL_BODY_META, // type
+		nullptr, // next
+		false, // supportsFullBodyTracking
+	};
+
+// @todo GH Issue 304: Remove check for meta headers when feature becomes part of OpenXR spec.
+#ifdef META_HEADERS_ENABLED
+	// META_body_tracking_fidelity extension.
+public:
+	enum BodyTrackingFidelity {
+		BODY_TRACKING_FIDELITY_UNKNOWN,
+		BODY_TRACKING_FIDELITY_LOW,
+		BODY_TRACKING_FIDELITY_HIGH,
+	};
+
+	bool is_body_tracking_fidelity_supported();
+
+	void request_body_tracking_fidelity(BodyTrackingFidelity p_fidelity);
+
+	BodyTrackingFidelity get_body_tracking_fidelity_status();
+
+private:
+	EXT_PROTO_XRRESULT_FUNC2(xrRequestBodyTrackingFidelityMETA,
+			(XrBodyTrackerFB), bodyTracker,
+			(const XrBodyTrackingFidelityMETA), fidelity)
+
+	bool initialize_meta_body_tracking_fidelity_extension(XrInstance p_instance);
+
+	bool meta_body_tracking_fidelity_ext = false;
+
+	XrSystemPropertiesBodyTrackingFidelityMETA system_body_tracking_fidelity_properties = {
+		XR_TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_FIDELITY_META, // type
+		nullptr, // next
+		false, // supportsBodyTrackingFidelity
+	};
+
+	XrBodyTrackingFidelityStatusMETA body_tracking_fidelity_status = {
+		XR_TYPE_BODY_TRACKING_FIDELITY_STATUS_META, // type
+		nullptr, // next
+		XR_BODY_TRACKING_FIDELITY_HIGH_META, // fidelity
+	};
+
+	// META_body_tracking_calibration extension.
+public:
+	enum BodyTrackingCalibrationState {
+		BODY_TRACKING_CALIBRATION_STATE_VALID,
+		BODY_TRACKING_CALIBRATION_STATE_CALIBRATING,
+		BODY_TRACKING_CALIBRATION_STATE_INVALID,
+	};
+
+	bool is_body_tracking_height_override_supported();
+
+	void suggest_body_tracking_height_override(float p_body_height);
+
+	BodyTrackingCalibrationState get_body_tracking_calibration_state();
+
+	void reset_body_tracking_calibration();
+
+private:
+	EXT_PROTO_XRRESULT_FUNC2(xrSuggestBodyTrackingCalibrationOverrideMETA,
+			(XrBodyTrackerFB), bodyTracker,
+			(const XrBodyTrackingCalibrationInfoMETA *), calibrationInfo)
+
+	EXT_PROTO_XRRESULT_FUNC1(xrResetBodyTrackingCalibrationMETA,
+			(XrBodyTrackerFB), bodyTracker)
+
+	bool initialize_meta_body_tracking_calibration_extension(XrInstance p_instance);
+
+	bool meta_body_tracking_calibration_ext = false;
+
+	XrSystemPropertiesBodyTrackingCalibrationMETA system_body_tracking_calibration_properties = {
+		XR_TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_CALIBRATION_META, // type
+		nullptr, // next
+		false, // supportsHeightOverride
+	};
+
+	XrBodyTrackingCalibrationStatusMETA body_tracking_calibration_status = {
+		XR_TYPE_BODY_TRACKING_CALIBRATION_STATUS_META, // type
+		nullptr, // next
+		XR_BODY_TRACKING_CALIBRATION_STATE_INVALID_META, // status
+	};
+#endif
 };
+
+// @todo GH Issue 304: Remove check for meta headers when feature becomes part of OpenXR spec.
+#ifdef META_HEADERS_ENABLED
+VARIANT_ENUM_CAST(OpenXRFbBodyTrackingExtensionWrapper::BodyTrackingFidelity);
+VARIANT_ENUM_CAST(OpenXRFbBodyTrackingExtensionWrapper::BodyTrackingCalibrationState);
+#endif
 
 #endif // OPENXR_FB_BODY_TRACKING_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -283,6 +283,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			_register_extension_as_singleton(OpenXRFbSceneExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRFbHandTrackingAimExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRFbHandTrackingCapsulesExtensionWrapper::get_singleton());
+			_register_extension_as_singleton(OpenXRFbBodyTrackingExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRHtcFacialTrackingExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRHtcPassthroughExtensionWrapper::get_singleton());
 

--- a/samples/meta-body-tracking-sample/main.tscn
+++ b/samples/meta-body-tracking-sample/main.tscn
@@ -93,22 +93,19 @@ bones/25/name = "RightLittleTip"
 hand_tracker = &"/user/hand_tracker/right"
 
 [node name="Floor" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.059405804, 0)
 mesh = SubResource("PlaneMesh_mjcgt")
 
-[node name="AvatarOffset" type="Node3D" parent="Floor"]
+[node name="AvatarOffset" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -1)
 
-[node name="Avatar" type="XRNode3D" parent="Floor/AvatarOffset"]
-tracker = &"/user/body_tracker"
+[node name="Test-Kun" parent="AvatarOffset" instance=ExtResource("4_b317s")]
 
-[node name="Test-Kun" parent="Floor/AvatarOffset/Avatar" instance=ExtResource("4_b317s")]
-transform = Transform3D(-1, 0, 8.74228e-08, 0, 1, 0, -8.74228e-08, 0, -1, 0, 0, 0)
-
-[node name="XRBodyModifier3D" type="XRBodyModifier3D" parent="Floor/AvatarOffset/Avatar/Test-Kun/Armature/GeneralSkeleton" index="2"]
+[node name="XRBodyModifier3D" type="XRBodyModifier3D" parent="AvatarOffset/Test-Kun/Armature/GeneralSkeleton" index="2"]
 transform = Transform3D(1, 0, 1.74846e-07, 0, 1, 0, -1.74846e-07, 0, 1, -8.74228e-08, 0, -1)
 bone_update = 1
 
-[node name="XRFaceModifier3D" type="XRFaceModifier3D" parent="Floor/AvatarOffset/Avatar"]
+[node name="XRFaceModifier3D" type="XRFaceModifier3D" parent="AvatarOffset"]
 target = NodePath("../Test-Kun/Armature/GeneralSkeleton/Body")
 
-[editable path="Floor/AvatarOffset/Avatar/Test-Kun"]
+[editable path="AvatarOffset/Test-Kun"]

--- a/samples/meta-body-tracking-sample/tests/test1.vrs
+++ b/samples/meta-body-tracking-sample/tests/test1.vrs
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c6e1694fd88e6d3db90af801dddbbec832cbb1167fbc04c7e34821d7ab3dc5a0
-size 5911083
+oid sha256:73e3b15420545bbd03101cfe48e398b56b3867defd1c9072e635ed86bd90fed8
+size 5316233


### PR DESCRIPTION
~~Builds on top of #310, so this PR will remain as a draft until the first is merged.~~

This PR implements the following Meta body tracking extensions, adding functionality to the preexisting `OpenXRFbBodyTrackingExtensionWrapper`:
- META_body_tracking_full_body
- META_body_tracking_fidelity
- META_body_tracking_calibration

META_body_tracking_full_body provides tracking for the lower body joints on a Godot humanoid skeleton! You can test this with the Meta body tracking sample. In order to keep compatibility, not all full body joints are implemented, as this would require the additional joints in `XRBodyTracker` added in https://github.com/godotengine/godot/pull/107220. These additional joints can be added in a future PR.

META_body_tracking_fidelity and META_body_tracking_calibration are not yet a part of the OpenXR spec, so their implementations are in `META_HEADERS_ENABLED` preprocessor checks. Once this PR is merged I'll add them to the issue tracking these additions: #304 