### PR TITLE
OpenXRFbSceneManager: Clarify how to check if scene capture is possible

### DIFF
--- a/doc_classes/OpenXRFbSceneCaptureExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbSceneCaptureExtensionWrapper.xml
@@ -12,13 +12,13 @@
 		<method name="is_scene_capture_enabled" deprecated="Use [method OpenXRFbSceneManager.is_scene_capture_enabled] instead.">
 			<return type="bool" />
 			<description>
-				Checks if this extension is enabled.
+				Returns [code]true[/code] if the scene capture process is currently in progress; otherwise [code]false[/code].
 			</description>
 		</method>
-		<method name="is_scene_capture_supported" deprecated="Use [method OpenXRFbSceneManager.is_scene_capture_enabled] instead.">
+		<method name="is_scene_capture_supported" deprecated="Use [method OpenXRFbSceneManager.is_scene_capture_supported] instead.">
 			<return type="bool" />
 			<description>
-				Checks if scene capture is supported.
+				Returns [code]true[/code] if scene capture is supported; otherwise [code]false[/code].
 			</description>
 		</method>
 		<method name="request_scene_capture" deprecated="Use [method OpenXRFbSceneManager.request_scene_capture] instead.">

--- a/doc_classes/OpenXRFbSceneManager.xml
+++ b/doc_classes/OpenXRFbSceneManager.xml
@@ -57,7 +57,13 @@
 		<method name="is_scene_capture_enabled" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Checks if scene capture is enabled.
+				Returns [code]true[/code] if the scene capture process is currently in progress; otherwise [code]false[/code].
+			</description>
+		</method>
+		<method name="is_scene_capture_supported" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if scene capture is supported; otherwise [code]false[/code].
 			</description>
 		</method>
 		<method name="remove_scene_anchors">

--- a/plugin/src/main/cpp/classes/openxr_fb_scene_manager.cpp
+++ b/plugin/src/main/cpp/classes/openxr_fb_scene_manager.cpp
@@ -61,6 +61,7 @@ void OpenXRFbSceneManager::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("request_scene_capture", "request"), &OpenXRFbSceneManager::request_scene_capture, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("is_scene_capture_enabled"), &OpenXRFbSceneManager::is_scene_capture_enabled);
+	ClassDB::bind_method(D_METHOD("is_scene_capture_supported"), &OpenXRFbSceneManager::is_scene_capture_supported);
 
 	ClassDB::bind_method(D_METHOD("get_anchor_uuids"), &OpenXRFbSceneManager::get_anchor_uuids);
 	ClassDB::bind_method(D_METHOD("get_anchor_node", "uuid"), &OpenXRFbSceneManager::get_anchor_node);
@@ -343,6 +344,10 @@ bool OpenXRFbSceneManager::request_scene_capture(const String &p_request) const 
 
 bool OpenXRFbSceneManager::is_scene_capture_enabled() const {
 	return OpenXRFbSceneCaptureExtensionWrapper::get_singleton()->is_scene_capture_enabled();
+}
+
+bool OpenXRFbSceneManager::is_scene_capture_supported() const {
+	return OpenXRFbSceneCaptureExtensionWrapper::get_singleton()->is_scene_capture_supported();
 }
 
 void OpenXRFbSceneManager::_scene_capture_callback(XrResult p_result, void *p_userdata) {

--- a/plugin/src/main/cpp/include/classes/openxr_fb_scene_manager.h
+++ b/plugin/src/main/cpp/include/classes/openxr_fb_scene_manager.h
@@ -107,6 +107,7 @@ public:
 
 	bool request_scene_capture(const String &p_request = "") const;
 	bool is_scene_capture_enabled() const;
+	bool is_scene_capture_supported() const;
 
 	static void _scene_capture_callback(XrResult p_result, void *p_userdata);
 


### PR DESCRIPTION
Fixes https://github.com/GodotVR/godot_openxr_vendors/issues/316

This clarifies the difference between `is_scene_capture_enabled()` and `is_scene_capture_supported()` in the docs, and exposes the latter on `OpenXRFbSceneManager`, which is what most users will interact with