### PR TITLE
Only display color space warnings when runtime default is set

### DIFF
--- a/plugin/src/main/cpp/export/meta_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/meta_export_plugin.cpp
@@ -291,7 +291,7 @@ String MetaEditorExportPlugin::_get_export_option_warning(const Ref<EditorExport
 		}
 	} else if (option == "xr_features/enable_meta_plugin") {
 		if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/color_space")) {
-			if ((int)project_settings->get_setting_with_override("xr/openxr/extensions/meta/color_space/starting_color_space") != 3) {
+			if ((int)project_settings->get_setting_with_override("xr/openxr/extensions/meta/color_space/starting_color_space") == 0) {
 				return "\"Recommended color space is REC709, this can be updated in OpenXR project settings.\"";
 			}
 		}

--- a/plugin/src/main/cpp/extensions/openxr_fb_color_space_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_color_space_extension_wrapper.cpp
@@ -261,10 +261,9 @@ void OpenXRFbColorSpaceExtensionWrapper::_on_state_ready() {
 	ERR_FAIL_NULL(project_settings);
 
 	ColorSpace starting_color_space = ColorSpace((int)project_settings->get_setting_with_override("xr/openxr/extensions/meta/color_space/starting_color_space"));
-	if (starting_color_space != COLOR_SPACE_REC709) {
+	if (starting_color_space == COLOR_SPACE_RUNTIME_DEFAULT) {
 		WARN_PRINT("Recommended color space project setting is REC709");
-	}
-	if (starting_color_space != COLOR_SPACE_RUNTIME_DEFAULT) {
+	} else {
 		set_color_space(starting_color_space);
 	}
 }


### PR DESCRIPTION
Per the discussion in #307, this would make the warnings less intrusive, as currently if a user wants something other than Rec 709 they will _always_ receive warnings.