### PR TITLE
Implement XR_META_simultaneous_hands_and_controllers extension

### DIFF
--- a/doc_classes/OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper.xml
+++ b/doc_classes/OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Wraps the [code]XR_META_simultaneous_hands_and_controllers[/code] extension.
+	</brief_description>
+	<description>
+		Wraps the [code]XR_META_simultaneous_hands_and_controllers[/code] extension.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="is_simultaneous_hands_and_controllers_supported">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the simultaneous hands and controllers extension is supported.
+			</description>
+		</method>
+		<method name="pause_simultaneous_hands_and_controllers_tracking">
+			<return type="void" />
+			<description>
+				Pause simultaneous hands and controllers tracking.
+			</description>
+		</method>
+		<method name="resume_simultaneous_hands_and_controllers_tracking">
+			<return type="void" />
+			<description>
+				Resume simultaneous hands and controllers tracking.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/plugin/src/main/cpp/extensions/openxr_meta_simultaneous_hands_and_controllers_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_meta_simultaneous_hands_and_controllers_extension_wrapper.cpp
@@ -1,0 +1,126 @@
+/**************************************************************************/
+/*  openxr_meta_simultaneous_hands_and_controllers_extension_wrapper.cpp  */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "extensions/openxr_meta_simultaneous_hands_and_controllers_extension_wrapper.h"
+#include "openxr/openxr.h"
+
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+
+using namespace godot;
+
+OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper *OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::singleton = nullptr;
+
+OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper *OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_META_SIMULTANEOUS_HANDS_AND_CONTROLLERS_EXTENSION_NAME] = &meta_simultaneous_hands_and_controllers_ext;
+	singleton = this;
+}
+
+OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::~OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper() {
+	cleanup();
+	singleton = nullptr;
+}
+
+godot::Dictionary OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::_get_requested_extensions() {
+	godot::Dictionary result;
+	for (auto ext : request_extensions) {
+		godot::String key = ext.first;
+		uint64_t value = reinterpret_cast<uint64_t>(ext.second);
+		result[key] = (godot::Variant)value;
+	}
+	return result;
+}
+
+uint64_t OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::_set_system_properties_and_get_next_pointer(void *p_next_pointer) {
+	if (meta_simultaneous_hands_and_controllers_ext) {
+		simultaneous_hands_and_controllers_properties.next = p_next_pointer;
+		p_next_pointer = &simultaneous_hands_and_controllers_properties;
+	}
+
+	return reinterpret_cast<uint64_t>(p_next_pointer);
+}
+
+void OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::_on_instance_created(uint64_t p_instance) {
+	if (meta_simultaneous_hands_and_controllers_ext) {
+		bool result = initialize_meta_simultaneous_hands_and_controllers_extension((XrInstance)p_instance);
+		if (!result) {
+			ERR_PRINT("Failed to initialize meta_simultaneous_hands_and_controllers extension");
+			meta_simultaneous_hands_and_controllers_ext = false;
+		}
+	}
+}
+
+void OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+bool OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::is_simultaneous_hands_and_controllers_supported() {
+	return simultaneous_hands_and_controllers_properties.supportsSimultaneousHandsAndControllers;
+}
+
+void OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::resume_simultaneous_hands_and_controllers_tracking() {
+	ERR_FAIL_COND_MSG(!meta_simultaneous_hands_and_controllers_ext, "XR_META_simultaneous_hands_and_controllers extension is not enabled");
+
+	XrResult result = xrResumeSimultaneousHandsAndControllersTrackingMETA(SESSION, &simultaneous_hands_and_controllers_tracking_resume_info);
+	ERR_FAIL_COND_MSG(XR_FAILED(result), vformat("Failed to resume simultaneous hands and controllers tracking [%s]", get_openxr_api()->get_error_string(result)));
+}
+
+void OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::pause_simultaneous_hands_and_controllers_tracking() {
+	ERR_FAIL_COND_MSG(!meta_simultaneous_hands_and_controllers_ext, "XR_META_simultaneous_hands_and_controllers extension is not enabled");
+
+	XrResult result = xrPauseSimultaneousHandsAndControllersTrackingMETA(SESSION, &simultaneous_hands_and_controllers_tracking_pause_info);
+	ERR_FAIL_COND_MSG(XR_FAILED(result), vformat("Failed to pause simultaneous hands and controllers tracking [%s]", get_openxr_api()->get_error_string(result)));
+}
+
+void OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_simultaneous_hands_and_controllers_supported"), &OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::is_simultaneous_hands_and_controllers_supported);
+
+	ClassDB::bind_method(D_METHOD("resume_simultaneous_hands_and_controllers_tracking"), &OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::resume_simultaneous_hands_and_controllers_tracking);
+	ClassDB::bind_method(D_METHOD("pause_simultaneous_hands_and_controllers_tracking"), &OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::pause_simultaneous_hands_and_controllers_tracking);
+}
+
+void OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::cleanup() {
+	meta_simultaneous_hands_and_controllers_ext = false;
+}
+
+bool OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::initialize_meta_simultaneous_hands_and_controllers_extension(XrInstance p_instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrResumeSimultaneousHandsAndControllersTrackingMETA);
+	GDEXTENSION_INIT_XR_FUNC_V(xrPauseSimultaneousHandsAndControllersTrackingMETA);
+
+	return true;
+}

--- a/plugin/src/main/cpp/include/extensions/openxr_meta_simultaneous_hands_and_controllers_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_meta_simultaneous_hands_and_controllers_extension_wrapper.h
@@ -1,0 +1,96 @@
+/**************************************************************************/
+/*  openxr_meta_simultaneous_hands_and_controllers_extension_wrapper.h    */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <openxr/openxr.h>
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <map>
+
+#include "util.h"
+
+using namespace godot;
+
+class OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	static OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper *get_singleton();
+
+	OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper();
+	~OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper();
+
+	godot::Dictionary _get_requested_extensions() override;
+
+	uint64_t _set_system_properties_and_get_next_pointer(void *p_next_pointer) override;
+	void _on_instance_created(uint64_t p_instance) override;
+	void _on_instance_destroyed() override;
+
+	bool is_simultaneous_hands_and_controllers_supported();
+
+	void resume_simultaneous_hands_and_controllers_tracking();
+	void pause_simultaneous_hands_and_controllers_tracking();
+
+protected:
+	static void _bind_methods();
+
+private:
+	EXT_PROTO_XRRESULT_FUNC2(xrResumeSimultaneousHandsAndControllersTrackingMETA,
+			(XrSession), session,
+			(const XrSimultaneousHandsAndControllersTrackingResumeInfoMETA *), resumeInfo)
+
+	EXT_PROTO_XRRESULT_FUNC2(xrPauseSimultaneousHandsAndControllersTrackingMETA,
+			(XrSession), session,
+			(const XrSimultaneousHandsAndControllersTrackingPauseInfoMETA *), pauseInfo)
+
+	bool initialize_meta_simultaneous_hands_and_controllers_extension(XrInstance p_instance);
+
+	void cleanup();
+
+	static OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper *singleton;
+
+	std::map<godot::String, bool *> request_extensions;
+	bool meta_simultaneous_hands_and_controllers_ext = false;
+
+	XrSystemSimultaneousHandsAndControllersPropertiesMETA simultaneous_hands_and_controllers_properties = {
+		XR_TYPE_SYSTEM_SIMULTANEOUS_HANDS_AND_CONTROLLERS_PROPERTIES_META, // type
+		nullptr, // next
+		false // supportsSimultaneousHandsAndControllers
+	};
+
+	const XrSimultaneousHandsAndControllersTrackingResumeInfoMETA simultaneous_hands_and_controllers_tracking_resume_info = {
+		XR_TYPE_SIMULTANEOUS_HANDS_AND_CONTROLLERS_TRACKING_RESUME_INFO_META, // type
+		nullptr // next
+	};
+
+	const XrSimultaneousHandsAndControllersTrackingPauseInfoMETA simultaneous_hands_and_controllers_tracking_pause_info = {
+		XR_TYPE_SIMULTANEOUS_HANDS_AND_CONTROLLERS_TRACKING_PAUSE_INFO_META, // type
+		nullptr, // next
+	};
+};

--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -75,6 +75,7 @@
 #include "extensions/openxr_meta_boundary_visibility_extension_wrapper.h"
 #include "extensions/openxr_meta_environment_depth_extension_wrapper.h"
 #include "extensions/openxr_meta_recommended_layer_resolution_extension_wrapper.h"
+#include "extensions/openxr_meta_simultaneous_hands_and_controllers_extension_wrapper.h"
 #include "extensions/openxr_meta_spatial_entity_mesh_extension_wrapper.h"
 
 #include "classes/openxr_fb_hand_tracking_mesh.h"
@@ -146,6 +147,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			GDREGISTER_CLASS(OpenXRFbSpatialEntityContainerExtensionWrapper);
 			GDREGISTER_CLASS(OpenXRFbSpatialEntityUserExtensionWrapper);
 			GDREGISTER_CLASS(OpenXRMetaRecommendedLayerResolutionExtensionWrapper);
+			GDREGISTER_CLASS(OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper);
 			GDREGISTER_CLASS(OpenXRMetaSpatialEntityMeshExtensionWrapper);
 			GDREGISTER_CLASS(OpenXRFbSceneExtensionWrapper);
 			GDREGISTER_CLASS(OpenXRFbFaceTrackingExtensionWrapper);
@@ -228,6 +230,10 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 				if (_get_bool_project_setting("xr/openxr/extensions/meta/hand_tracking_capsules")) {
 					_register_extension_with_openxr(OpenXRFbHandTrackingCapsulesExtensionWrapper::get_singleton());
 				}
+
+				if (_get_bool_project_setting("xr/openxr/extensions/meta/simultaneous_hands_and_controllers")) {
+					_register_extension_with_openxr(OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::get_singleton());
+				}
 			}
 
 			if (_get_bool_project_setting("xr/openxr/extensions/meta/composition_layer_settings")) {
@@ -284,6 +290,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			_register_extension_as_singleton(OpenXRFbSceneExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRFbHandTrackingAimExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRFbHandTrackingCapsulesExtensionWrapper::get_singleton());
+			_register_extension_as_singleton(OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRFbBodyTrackingExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRHtcFacialTrackingExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRHtcPassthroughExtensionWrapper::get_singleton());
@@ -418,6 +425,7 @@ void add_plugin_project_settings() {
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/hand_tracking_aim", false);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/hand_tracking_mesh", false);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/hand_tracking_capsules", false);
+	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/simultaneous_hands_and_controllers", false);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/render_model", false);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/anchor_api", false);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/anchor_sharing", false);


### PR DESCRIPTION
Adds implementation of the [`XR_META_simultaneous_hands_and_controllers`](https://registry.khronos.org/OpenXR/specs/1.1/html/xrspec.html#XR_META_simultaneous_hands_and_controllers) extension. Really simple extension wrapper. Just has a function to check if the feature is supported, and functions to resume/pause it.

Right now the only thing of note in testing is that upon pausing simultaneous tracking, a few of the following errors print out:
```
hand_controller.gd:33 @ _process(): Condition "!v.is_finite()" is true.
```

The errors are printed from `RenderSceneCull::instance_set_transform()`, not sure why at the moment (will try to look into more soon). I know I see this error printed elsewhere from time to time, I believe related to render models or hand tracking meshes. So, I don't think this extension does anything wrong and could still be merged. Perhaps an issue should be made to track this `!v.s_finite()` error? I'll possibly do that after looking into it a bit more.