### PR TITLE
Only delete `android` and `.godot` directories from samples if running `zipSamples` task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -227,22 +227,24 @@ task zipSamples {
     destinationDir.mkdirs()
 
     directoriesToZip.each { dir ->
-        def godotFolder = new File(dir, '.godot')
-        if (godotFolder.exists()) {
-            godotFolder.deleteDir()
-        }
-
-        def androidFolder = new File(dir, 'android')
-        if (androidFolder.exists()) {
-            androidFolder.deleteDir()
-        }
-
         def zipTask = tasks.create(name: "zip${dir.name.capitalize()}", type: Zip) {
             from(dir.parentFile) {
                 include "${dir.name}/**"
             }
             archiveFileName = "${dir.name}.zip"
             destinationDirectory = destinationDir
+        }
+
+        zipTask.doFirst {
+            def godotFolder = new File(dir, '.godot')
+            if (godotFolder.exists()) {
+                godotFolder.deleteDir()
+            }
+
+            def androidFolder = new File(dir, 'android')
+            if (androidFolder.exists()) {
+                androidFolder.deleteDir()
+            }
         }
 
         dependsOn zipTask


### PR DESCRIPTION
Currently, if you run any Gradle task, it will delete the `.godot` and `android` directories in every sample.

This is super annoying when not working on Godot itself, because I'd like to be able to keep those intact, and just run the project again with only the rebuilt vendor extension.

This PR fixes it so that they'll only be deleted if the `zipSamples` task actually runs (rather than deleting them when the task is just being configured)