### PR TITLE
Fix vendor performance metrics setter logic

### DIFF
--- a/plugin/src/main/cpp/classes/openxr_vendor_performance_metrics.cpp
+++ b/plugin/src/main/cpp/classes/openxr_vendor_performance_metrics.cpp
@@ -66,15 +66,12 @@ bool OpenXRVendorPerformanceMetrics::is_enabled() {
 }
 
 void OpenXRVendorPerformanceMetrics::set_vendor_performance_metrics_provider(OpenXRVendorPerformanceMetricsProvider *p_provider) {
-	if (provider == p_provider) {
+	if (provider != nullptr && provider->is_enabled()) {
+		WARN_PRINT("An OpenXRVendorPerformanceMetricsProvider is already set; ignoring new provider");
 		return;
 	}
 
 	provider = p_provider;
-}
-
-OpenXRVendorPerformanceMetricsProvider *OpenXRVendorPerformanceMetrics::get_vendor_performance_metrics_provider() {
-	return provider;
 }
 
 void OpenXRVendorPerformanceMetrics::set_capture_performance_metrics(bool p_enabled) {

--- a/plugin/src/main/cpp/extensions/openxr_meta_performance_metrics_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_meta_performance_metrics_extension_wrapper.cpp
@@ -83,10 +83,7 @@ void OpenXRMetaPerformanceMetricsExtensionWrapper::_on_instance_created(uint64_t
 			return;
 		}
 
-		OpenXRVendorPerformanceMetrics *vendor_performance_metrics = OpenXRVendorPerformanceMetrics::get_singleton();
-		if (vendor_performance_metrics->get_vendor_performance_metrics_provider() != nullptr) {
-			vendor_performance_metrics->set_vendor_performance_metrics_provider(this);
-		}
+		OpenXRVendorPerformanceMetrics::get_singleton()->set_vendor_performance_metrics_provider(this);
 	}
 }
 

--- a/plugin/src/main/cpp/include/classes/openxr_vendor_performance_metrics.h
+++ b/plugin/src/main/cpp/include/classes/openxr_vendor_performance_metrics.h
@@ -62,7 +62,6 @@ public:
 	bool is_enabled();
 
 	void set_vendor_performance_metrics_provider(OpenXRVendorPerformanceMetricsProvider *p_provider);
-	OpenXRVendorPerformanceMetricsProvider *get_vendor_performance_metrics_provider();
 
 	void set_capture_performance_metrics(bool p_enabled);
 	bool is_capturing_performance_metrics();
@@ -77,7 +76,7 @@ protected:
 private:
 	static OpenXRVendorPerformanceMetrics *singleton;
 
-	OpenXRVendorPerformanceMetricsProvider *provider;
+	OpenXRVendorPerformanceMetricsProvider *provider = nullptr;
 
 	bool capture_performance_metrics = false;
 


### PR DESCRIPTION
Dumb typo on my end slipped in and went uncaught because I wasn't initializing `provider` as `nullptr`. 🙂 This should be correct now.