### PR TITLE
Fix running the meta-scene-sample on Godot 4.4

### DIFF
--- a/samples/meta-scene-sample/main.gd
+++ b/samples/meta-scene-sample/main.gd
@@ -17,7 +17,8 @@ var global_environment_depth_enabled: bool = true
 @onready var world_environment: WorldEnvironment = $WorldEnvironment
 @onready var scene_manager: OpenXRFbSceneManager = $XROrigin3D/OpenXRFbSceneManager
 @onready var spatial_anchor_manager: OpenXRFbSpatialAnchorManager = $XROrigin3D/OpenXRFbSpatialAnchorManager
-@onready var environment_depth_node: OpenXRMetaEnvironmentDepth = $XROrigin3D/XRCamera3D/OpenXRMetaEnvironmentDepth
+# Don't statically type this as `OpenXRMetaEnvironmentDepth` because it doesn't exist on Godot 4.4.
+@onready var environment_depth_node = $XROrigin3D/XRCamera3D/OpenXRMetaEnvironmentDepth
 @onready var depth_testing_mesh: MeshInstance3D = $XROrigin3D/RightHand/DepthTestingMesh
 
 const SPATIAL_ANCHORS_FILE = "user://openxr_fb_spatial_anchors.json"


### PR DESCRIPTION
Currently, if you try to run the `samples/meta-scene-sample` project on Godot 4.4, it'll get an error (and fail to work correctly):

```
ERROR: Cannot get class 'OpenXRMetaEnvironmentDepth'.
```

This is because that class is only registered on Godot 4.5!

This PR removes the type hint which allows it to run fine on Godot 4.4 again (but without environment depth, of course)