### PR TITLE
Use `gdformat` to ensure consistent GDScript coding standards in CI

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -3,15 +3,22 @@ on: [push, pull_request]
 
 jobs:
   static-checks:
-    name: Formatting (clang-format, file format)
+    name: Formatting (clang-format, file format, gdformat)
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
       - name: Install dependencies
         run: |
           sudo apt-get install -qq dos2unix recode clang-format
+          python -m pip install --upgrade pip
+          python -m pip install 'gdtoolkit==4.*'
 
       - name: File formatting checks (file_format.sh)
         run: |
@@ -20,3 +27,16 @@ jobs:
       - name: Style checks via clang-format (clang_format.sh)
         run: |
           bash ./.github/workflows/scripts/clang_format.sh
+
+      - name: GDScript style checks (gdformat)
+        run: |
+          FAILED=n
+          for d in demo samples/*-sample; do
+            echo "Linting GDScript in $d..."
+            if ! gdformat -d "$d"; then
+              FAILED=y
+            fi
+          done
+          if [ "$FAILED" = "y" ]; then
+            exit 1
+          fi

--- a/demo/hand_controller.gd
+++ b/demo/hand_controller.gd
@@ -3,11 +3,10 @@ extends XRController3D
 @onready var hand_cube: MeshInstance3D = $HandCube
 @onready var render_model: OpenXRFbRenderModel = $ControllerFbRenderModel
 
+
 func _process(_delta: float) -> void:
-	var hand_tracker_name = "/user/hand_tracker/left" if tracker == "left_hand" \
-			else "/user/hand_tracker/right"
-	var hand_tracker_hand: OpenXRInterface.Hand = OpenXRInterface.HAND_LEFT if tracker == "left_hand" \
-		else OpenXRInterface.HAND_RIGHT
+	var hand_tracker_name = "/user/hand_tracker/left" if tracker == "left_hand" else "/user/hand_tracker/right"
+	var hand_tracker_hand: OpenXRInterface.Hand = OpenXRInterface.HAND_LEFT if tracker == "left_hand" else OpenXRInterface.HAND_RIGHT
 
 	var interface: OpenXRInterface = XRServer.find_interface("OpenXR")
 
@@ -15,8 +14,7 @@ func _process(_delta: float) -> void:
 	if hand_tracker and hand_tracker.has_tracking_data:
 		# If hand tracking data is provided by controller,
 		# and controller model is available, show it with hand mesh.
-		if hand_tracker.hand_tracking_source == XRHandTracker.HAND_TRACKING_SOURCE_CONTROLLER \
-				and render_model.has_render_model_node():
+		if hand_tracker.hand_tracking_source == XRHandTracker.HAND_TRACKING_SOURCE_CONTROLLER and render_model.has_render_model_node():
 			render_model.show()
 			interface.set_motion_range(hand_tracker_hand, OpenXRInterface.HAND_MOTION_RANGE_CONFORM_TO_CONTROLLER)
 		# If hand tracking data is not provided by controller,

--- a/demo/hand_mesh.gd
+++ b/demo/hand_mesh.gd
@@ -1,5 +1,6 @@
 extends XRNode3D
 
+
 func _process(_delta: float) -> void:
 	var hand_tracker: XRHandTracker = XRServer.get_tracker(tracker)
 	if hand_tracker and hand_tracker.has_tracking_data:

--- a/demo/main.gd
+++ b/demo/main.gd
@@ -2,6 +2,7 @@ extends Node3D
 
 var xr_interface: XRInterface = null
 
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	xr_interface = XRServer.find_interface("OpenXR")

--- a/gdformatrc
+++ b/gdformatrc
@@ -1,0 +1,6 @@
+excluded_directories: !!set
+  .git: null
+# Effectively disable the line limit.
+line_length: 10000
+safety_checks: null
+use_spaces: null

--- a/samples/hybrid-app-sample/main.gd
+++ b/samples/hybrid-app-sample/main.gd
@@ -12,6 +12,7 @@ var pointer_pressed := false
 @onready var turkey = %Turkey
 @onready var right_controller_pointer: XRController3D = %RightControllerPointer
 
+
 func _ready() -> void:
 	var data_string: String = OpenXRHybridApp.get_launch_data()
 	if data_string != "":
@@ -19,7 +20,7 @@ func _ready() -> void:
 		print("Hybrid App Launch Data: ", data)
 
 		# Restore the turkey's rotation.
-		var turkey_rotation := Vector3(0.0, data.get('turkey_y_rotation', 0.0), 0.0)
+		var turkey_rotation := Vector3(0.0, data.get("turkey_y_rotation", 0.0), 0.0)
 		turkey.transform.basis = Basis.from_euler(turkey_rotation)
 
 	xr_interface = XRServer.find_interface("OpenXR")
@@ -44,6 +45,7 @@ func _ready() -> void:
 	print("Is Hybrid App: ", OpenXRHybridApp.is_hybrid_app())
 	print("Hybrid App Mode: ", OpenXRHybridApp.get_mode())
 
+
 func _physics_process(_delta: float) -> void:
 	# Make the gltf model slowly rotate
 	if turkey:
@@ -51,17 +53,20 @@ func _physics_process(_delta: float) -> void:
 
 		# Store the data in the panel switcher, so the turkey rotation is maintained in the other mode.
 		var turkey_rotation: Vector3 = turkey.transform.basis.get_euler()
-		panel_switcher.data['turkey_y_rotation'] = turkey_rotation.y
+		panel_switcher.data["turkey_y_rotation"] = turkey_rotation.y
+
 
 func _process(_delta: float) -> void:
 	if panel_switcher_layer:
 		var t: Transform3D = right_controller_pointer.global_transform
 		panel_switcher_layer.update_pointer(t.origin, -t.basis.z, pointer_pressed)
 
+
 func _on_right_controller_pointer_button_pressed(p_name: String) -> void:
-	if p_name == 'trigger_click':
+	if p_name == "trigger_click":
 		pointer_pressed = true
 
+
 func _on_right_controller_pointer_button_released(p_name: String) -> void:
-	if p_name == 'trigger_click':
+	if p_name == "trigger_click":
 		pointer_pressed = false

--- a/samples/hybrid-app-sample/panel_switcher.gd
+++ b/samples/hybrid-app-sample/panel_switcher.gd
@@ -5,6 +5,7 @@ extends Control
 var hybrid_app_mode := OpenXRHybridApp.HYBRID_MODE_NONE
 var data := {}
 
+
 func _ready() -> void:
 	hybrid_app_mode = OpenXRHybridApp.get_mode()
 	if hybrid_app_mode == OpenXRHybridApp.HYBRID_MODE_IMMERSIVE:
@@ -13,6 +14,7 @@ func _ready() -> void:
 		switch_button.text = "Switch To Immersive"
 	else:
 		switch_button.visible = false
+
 
 func _on_switch_button_pressed() -> void:
 	var data_string := JSON.stringify(data)

--- a/samples/hybrid-app-sample/panel_switcher_layer.gd
+++ b/samples/hybrid-app-sample/panel_switcher_layer.gd
@@ -10,8 +10,10 @@ const NO_INTERSECTION := Vector2(-1.0, -1.0)
 var previous_cursor_intersection: Vector2 = NO_INTERSECTION
 var previous_cursor_pressed := false
 
+
 func get_panel_switcher() -> PanelSwitcher:
 	return panel_switcher
+
 
 func update_pointer(p_origin: Vector3, p_direction: Vector3, p_pressed: bool) -> bool:
 	var viewport_size: Vector2 = layer_viewport.size

--- a/samples/hybrid-app-sample/start_xr.gd
+++ b/samples/hybrid-app-sample/start_xr.gd
@@ -8,17 +8,18 @@ signal focus_lost
 signal focus_gained
 signal pose_recentered
 
-@export var maximum_refresh_rate : int = 90
+@export var maximum_refresh_rate: int = 90
 
-var xr_interface : OpenXRInterface
+var xr_interface: OpenXRInterface
 var xr_is_focussed = false
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	xr_interface = XRServer.find_interface("OpenXR")
 	if xr_interface and xr_interface.is_initialized():
 		print("OpenXR instantiated successfully.")
-		var vp : Viewport = get_viewport()
+		var vp: Viewport = get_viewport()
 
 		# Enable XR on our viewport
 		vp.use_xr = true
@@ -55,7 +56,7 @@ func _on_openxr_session_begun() -> void:
 
 	# See if we have a better refresh rate available
 	var new_rate = current_refresh_rate
-	var available_rates : Array = xr_interface.get_available_display_refresh_rates()
+	var available_rates: Array = xr_interface.get_available_display_refresh_rates()
 	if available_rates.size() == 0:
 		print("OpenXR: Target does not support refresh rate extension")
 	elif available_rates.size() == 1:

--- a/samples/meta-body-tracking-sample/start_xr.gd
+++ b/samples/meta-body-tracking-sample/start_xr.gd
@@ -8,17 +8,18 @@ signal focus_lost
 signal focus_gained
 signal pose_recentered
 
-@export var maximum_refresh_rate : int = 90
+@export var maximum_refresh_rate: int = 90
 
-var xr_interface : OpenXRInterface
+var xr_interface: OpenXRInterface
 var xr_is_focussed = false
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	xr_interface = XRServer.find_interface("OpenXR")
 	if xr_interface and xr_interface.is_initialized():
 		print("OpenXR instantiated successfully.")
-		var vp : Viewport = get_viewport()
+		var vp: Viewport = get_viewport()
 
 		# Enable XR on our viewport
 		vp.use_xr = true
@@ -55,7 +56,7 @@ func _on_openxr_session_begun() -> void:
 
 	# See if we have a better refresh rate available
 	var new_rate = current_refresh_rate
-	var available_rates : Array = xr_interface.get_available_display_refresh_rates()
+	var available_rates: Array = xr_interface.get_available_display_refresh_rates()
 	if available_rates.size() == 0:
 		print("OpenXR: Target does not support refresh rate extension")
 	elif available_rates.size() == 1:

--- a/samples/meta-composition-layers-sample/example_panel.gd
+++ b/samples/meta-composition-layers-sample/example_panel.gd
@@ -7,15 +7,18 @@ extends Control
 
 var start_pos: Vector2
 
+
 func _ready() -> void:
 	start_pos = $Label.position
 	$Label.text = display_string
+
 
 func _process(delta: float) -> void:
 	if not "--xrsim-automated-tests" in OS.get_cmdline_user_args():
 		# When we're running tests via the XR Simulator, we don't want the text
 		# to be animated, which can lead to differences in the screenshots.
 		$Label.position = Vector2(start_pos.x + (100.0 * sin(Time.get_ticks_msec() * 0.001 * 2)), start_pos.y)
+
 
 func update_pointers(p_position_left: Vector2, p_position_right: Vector2) -> void:
 	pointer_left.position = size * p_position_left - (0.5 * pointer_left.size)

--- a/samples/meta-composition-layers-sample/main.gd
+++ b/samples/meta-composition-layers-sample/main.gd
@@ -30,6 +30,7 @@ const TURN_ANGLE := TAU / 16
 @onready var replace_secure_content_mesh: MeshInstance3D = $XROrigin3D/SecureContentCompositionLayer/ReplaceSecureContent/MeshInstance3D
 @onready var exclude_secure_content_mesh: MeshInstance3D = $XROrigin3D/SecureContentCompositionLayer/ExcludeSecureContent/MeshInstance3D
 
+
 func _ready():
 	super._ready()
 

--- a/samples/meta-composition-layers-sample/raycast.gd
+++ b/samples/meta-composition-layers-sample/raycast.gd
@@ -2,6 +2,7 @@ extends RayCast3D
 
 @onready var mesh_instance_3d: MeshInstance3D = $MeshInstance3D
 
+
 func _process(delta: float) -> void:
 	var mat = mesh_instance_3d.get_surface_override_material(0)
 

--- a/samples/meta-composition-layers-sample/start_xr.gd
+++ b/samples/meta-composition-layers-sample/start_xr.gd
@@ -8,17 +8,18 @@ signal focus_lost
 signal focus_gained
 signal pose_recentered
 
-@export var maximum_refresh_rate : int = 90
+@export var maximum_refresh_rate: int = 90
 
-var xr_interface : OpenXRInterface
+var xr_interface: OpenXRInterface
 var xr_is_focussed = false
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	xr_interface = XRServer.find_interface("OpenXR")
 	if xr_interface and xr_interface.is_initialized():
 		print("OpenXR instantiated successfully.")
-		var vp : Viewport = get_viewport()
+		var vp: Viewport = get_viewport()
 
 		# Enable XR on our viewport
 		vp.use_xr = true
@@ -55,7 +56,7 @@ func _on_openxr_session_begun() -> void:
 
 	# See if we have a better refresh rate available
 	var new_rate = current_refresh_rate
-	var available_rates : Array = xr_interface.get_available_display_refresh_rates()
+	var available_rates: Array = xr_interface.get_available_display_refresh_rates()
 	if available_rates.size() == 0:
 		print("OpenXR: Target does not support refresh rate extension")
 	elif available_rates.size() == 1:

--- a/samples/meta-hand-tracking-sample/main.gd
+++ b/samples/meta-hand-tracking-sample/main.gd
@@ -35,6 +35,7 @@ var countdown_to_group_hand_meshes := 3
 var left_capsules_loaded := false
 var right_capsules_loaded := false
 
+
 func _ready() -> void:
 	super._ready()
 	if xr_interface and xr_interface.is_initialized():
@@ -55,11 +56,11 @@ func _process(delta):
 	if not left_capsules_loaded:
 		var tracker: XRHandTracker = XRServer.get_tracker("/user/hand_tracker/left")
 		if tracker and tracker.has_tracking_data:
-				hand_capsule_setup(0, tracker)
+			hand_capsule_setup(0, tracker)
 	if not right_capsules_loaded:
 		var tracker: XRHandTracker = XRServer.get_tracker("/user/hand_tracker/right")
 		if tracker and tracker.has_tracking_data:
-				hand_capsule_setup(1, tracker)
+			hand_capsule_setup(1, tracker)
 
 
 func hand_capsule_setup(hand_idx: int, hand_tracker: XRHandTracker) -> void:
@@ -94,6 +95,7 @@ func hand_capsule_setup(hand_idx: int, hand_tracker: XRHandTracker) -> void:
 			left_capsules_loaded = true
 		1:
 			right_capsules_loaded = true
+
 
 func _on_left_controller_input_float_changed(name: String, value: float) -> void:
 	match name:

--- a/samples/meta-hand-tracking-sample/raycast.gd
+++ b/samples/meta-hand-tracking-sample/raycast.gd
@@ -4,6 +4,7 @@ extends RayCast3D
 
 var is_active: bool = false
 
+
 func _process(delta: float) -> void:
 	var mat = mesh_instance_3d.get_surface_override_material(0)
 

--- a/samples/meta-hand-tracking-sample/start_xr.gd
+++ b/samples/meta-hand-tracking-sample/start_xr.gd
@@ -8,17 +8,18 @@ signal focus_lost
 signal focus_gained
 signal pose_recentered
 
-@export var maximum_refresh_rate : int = 90
+@export var maximum_refresh_rate: int = 90
 
-var xr_interface : OpenXRInterface
+var xr_interface: OpenXRInterface
 var xr_is_focussed = false
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	xr_interface = XRServer.find_interface("OpenXR")
 	if xr_interface and xr_interface.is_initialized():
 		print("OpenXR instantiated successfully.")
-		var vp : Viewport = get_viewport()
+		var vp: Viewport = get_viewport()
 
 		# Enable XR on our viewport
 		vp.use_xr = true
@@ -55,7 +56,7 @@ func _on_openxr_session_begun() -> void:
 
 	# See if we have a better refresh rate available
 	var new_rate = current_refresh_rate
-	var available_rates : Array = xr_interface.get_available_display_refresh_rates()
+	var available_rates: Array = xr_interface.get_available_display_refresh_rates()
 	if available_rates.size() == 0:
 		print("OpenXR: Target does not support refresh rate extension")
 	elif available_rates.size() == 1:

--- a/samples/meta-passthrough-sample/main.gd
+++ b/samples/meta-passthrough-sample/main.gd
@@ -26,6 +26,7 @@ var countdown_to_recenter_hmd: int = 3
 @onready var color_map_mesh: MeshInstance3D = $Interfaces/InterfaceColorMap/ColorMapMesh
 @onready var mono_map_mesh: MeshInstance3D = $Interfaces/InterfaceMonoMap/MonoMapMesh
 
+
 func _ready() -> void:
 	super._ready()
 
@@ -142,24 +143,24 @@ func update(to_update: String) -> void:
 			child.hide()
 
 	match to_update:
-			"ModeFull":
-				enable_mode_full()
-			"ModeGeometry":
-				enable_mode_geometry()
-			"ModeGeometryHP":
-				enable_mode_geometry_hp()
-			"FilterColorMap":
-				enable_filter_color_map()
-			"FilterMonoMap":
-				enable_filter_mono_map()
-			"FilterBrightnessContrastSaturation":
-				enable_filter_brightness_contrast_saturation()
-			"FilterColorMapLUT":
-				enable_filter_color_map_lut()
-			"FilterColorMapInterpolatedLUT":
-				enable_filter_color_map_interpolated_lut()
-			"FilterDisabled":
-				disable_filters()
+		"ModeFull":
+			enable_mode_full()
+		"ModeGeometry":
+			enable_mode_geometry()
+		"ModeGeometryHP":
+			enable_mode_geometry_hp()
+		"FilterColorMap":
+			enable_filter_color_map()
+		"FilterMonoMap":
+			enable_filter_mono_map()
+		"FilterBrightnessContrastSaturation":
+			enable_filter_brightness_contrast_saturation()
+		"FilterColorMapLUT":
+			enable_filter_color_map_lut()
+		"FilterColorMapInterpolatedLUT":
+			enable_filter_color_map_interpolated_lut()
+		"FilterDisabled":
+			disable_filters()
 
 
 func _on_brightness_new_value(value: float) -> void:

--- a/samples/meta-passthrough-sample/raycast.gd
+++ b/samples/meta-passthrough-sample/raycast.gd
@@ -2,6 +2,7 @@ extends RayCast3D
 
 @onready var mesh_instance_3d: MeshInstance3D = $MeshInstance3D
 
+
 func _process(delta: float) -> void:
 	var mat = mesh_instance_3d.get_surface_override_material(0)
 

--- a/samples/meta-passthrough-sample/slider.gd
+++ b/samples/meta-passthrough-sample/slider.gd
@@ -15,6 +15,7 @@ var value: float
 @onready var collision_shape_3d: CollisionShape3D = $CollisionShape3D
 @onready var value_indicator: MeshInstance3D = $ValueIndicator
 
+
 func _ready() -> void:
 	extent = (collision_shape_3d.shape.size.x * 0.5) * 0.9
 	value_indicator.position.x = remap(start_value, 0.0, 1.0, -extent, extent)

--- a/samples/meta-passthrough-sample/start_xr.gd
+++ b/samples/meta-passthrough-sample/start_xr.gd
@@ -8,17 +8,18 @@ signal focus_lost
 signal focus_gained
 signal pose_recentered
 
-@export var maximum_refresh_rate : int = 90
+@export var maximum_refresh_rate: int = 90
 
-var xr_interface : OpenXRInterface
+var xr_interface: OpenXRInterface
 var xr_is_focussed = false
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	xr_interface = XRServer.find_interface("OpenXR")
 	if xr_interface and xr_interface.is_initialized():
 		print("OpenXR instantiated successfully.")
-		var vp : Viewport = get_viewport()
+		var vp: Viewport = get_viewport()
 
 		# Enable XR on our viewport
 		vp.use_xr = true
@@ -55,7 +56,7 @@ func _on_openxr_session_begun() -> void:
 
 	# See if we have a better refresh rate available
 	var new_rate = current_refresh_rate
-	var available_rates : Array = xr_interface.get_available_display_refresh_rates()
+	var available_rates: Array = xr_interface.get_available_display_refresh_rates()
 	if available_rates.size() == 0:
 		print("OpenXR: Target does not support refresh rate extension")
 	elif available_rates.size() == 1:

--- a/samples/meta-scene-sample/main.gd
+++ b/samples/meta-scene-sample/main.gd
@@ -26,15 +26,16 @@ const SPATIAL_ANCHORS_FILE = "user://openxr_fb_spatial_anchors.json"
 var _setup := false
 
 const COLORS = [
-	"#FF0000", # Red
-	"#00FF00", # Green
-	"#0000FF", # Blue
-	"#FFFF00", # Yellow
-	"#00FFFF", # Cyan
-	"#FF00FF", # Magenta
-	"#FF8000", # Orange
-	"#800080", # Purple
+	"#FF0000",  # Red
+	"#00FF00",  # Green
+	"#0000FF",  # Blue
+	"#FFFF00",  # Yellow
+	"#00FFFF",  # Cyan
+	"#FF00FF",  # Magenta
+	"#FF8000",  # Orange
+	"#800080",  # Purple
 ]
+
 
 func _ready():
 	super._ready()
@@ -204,10 +205,10 @@ func _on_right_hand_button_pressed(name: String) -> void:
 				else:
 					anchor_transform.basis = Basis.looking_at(right_hand_pointer_raycast.get_collision_normal())
 
-				spatial_anchor_manager.create_anchor(anchor_transform, { color = COLORS[randi() % COLORS.size()] })
+				spatial_anchor_manager.create_anchor(anchor_transform, {color = COLORS[randi() % COLORS.size()]})
 	elif name == "ax_button":
 		var anchor_transform := right_hand.transform
-		spatial_anchor_manager.create_anchor(anchor_transform, { color = COLORS[randi() % COLORS.size()] })
+		spatial_anchor_manager.create_anchor(anchor_transform, {color = COLORS[randi() % COLORS.size()]})
 	elif name == "by_button":
 		global_environment_depth_enabled = not global_environment_depth_enabled
 

--- a/samples/meta-scene-sample/scene_anchor.gd
+++ b/samples/meta-scene-sample/scene_anchor.gd
@@ -7,10 +7,11 @@ const MATERIAL = preload("res://assets/cross-grid-material.tres")
 
 var mesh_instance: MeshInstance3D
 
+
 func setup_scene(entity: OpenXRFbSpatialEntity) -> void:
 	var semantic_labels: PackedStringArray = entity.get_semantic_labels()
 
-	label.text = ", ".join(Array(semantic_labels).map(func (x): return x.capitalize()))
+	label.text = ", ".join(Array(semantic_labels).map(func(x): return x.capitalize()))
 
 	var collision_shape = entity.create_collision_shape()
 	if collision_shape:
@@ -33,15 +34,16 @@ func setup_scene(entity: OpenXRFbSpatialEntity) -> void:
 
 	add_child(mesh_instance)
 
+
 func _get_color_for_label(semantic_label) -> Color:
 	match semantic_label:
-		"ceiling","floor":
+		"ceiling", "floor":
 			return Color(0.0, 0.0, 0.0, 1.0)
-		"wall_face","invisible_wall_face":
+		"wall_face", "invisible_wall_face":
 			return Color(0.0, 0.0, 1.0, 1.0)
-		"window_frame","door_frame":
+		"window_frame", "door_frame":
 			return Color(1.0, 0.0, 0.0, 1.0)
-		"couch","table","bed","lamp","plant","screen","storage":
+		"couch", "table", "bed", "lamp", "plant", "screen", "storage":
 			return Color(0.0, 1.0, 0.0, 1.0)
 
 	return Color(1.0, 1.0, 1.0, 1.0)

--- a/samples/meta-scene-sample/scene_global_mesh.gd
+++ b/samples/meta-scene-sample/scene_global_mesh.gd
@@ -6,6 +6,7 @@ const WIREFRAME_MATERIAL: Material = preload("res://assets/wireframe-material.tr
 
 var mesh_instance: MeshInstance3D
 
+
 func setup_scene(entity: OpenXRFbSpatialEntity) -> void:
 	var collision_shape = entity.create_collision_shape()
 	if collision_shape:

--- a/samples/meta-scene-sample/spatial_anchor.gd
+++ b/samples/meta-scene-sample/spatial_anchor.gd
@@ -5,16 +5,18 @@ extends Area3D
 var color: Color
 var selected := false
 
+
 func setup_scene(spatial_entity: OpenXRFbSpatialEntity) -> void:
 	var data: Dictionary = spatial_entity.custom_data
 
-	color = Color(data.get('color', '#FFFFFF'))
+	color = Color(data.get("color", "#FFFFFF"))
 
 	var material: StandardMaterial3D = mesh_instance.get_surface_override_material(0)
 	material.albedo_color = color
 	mesh_instance.set_surface_override_material(0, material)
 
 	spatial_entity.save_to_storage(OpenXRFbSpatialEntity.STORAGE_CLOUD)
+
 
 func set_selected(p_selected: bool) -> void:
 	selected = p_selected

--- a/samples/meta-scene-sample/start_xr.gd
+++ b/samples/meta-scene-sample/start_xr.gd
@@ -8,17 +8,18 @@ signal focus_lost
 signal focus_gained
 signal pose_recentered
 
-@export var maximum_refresh_rate : int = 90
+@export var maximum_refresh_rate: int = 90
 
-var xr_interface : OpenXRInterface
+var xr_interface: OpenXRInterface
 var xr_is_focussed = false
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	xr_interface = XRServer.find_interface("OpenXR")
 	if xr_interface and xr_interface.is_initialized():
 		print("OpenXR instantiated successfully.")
-		var vp : Viewport = get_viewport()
+		var vp: Viewport = get_viewport()
 
 		# Enable XR on our viewport
 		vp.use_xr = true
@@ -55,7 +56,7 @@ func _on_openxr_session_begun() -> void:
 
 	# See if we have a better refresh rate available
 	var new_rate = current_refresh_rate
-	var available_rates : Array = xr_interface.get_available_display_refresh_rates()
+	var available_rates: Array = xr_interface.get_available_display_refresh_rates()
 	if available_rates.size() == 0:
 		print("OpenXR: Target does not support refresh rate extension")
 	elif available_rates.size() == 1:

--- a/samples/meta-space-warp-sample/bone_cube.gd
+++ b/samples/meta-space-warp-sample/bone_cube.gd
@@ -2,6 +2,7 @@ extends Node3D
 
 @onready var skeleton := $Armature/Skeleton3D
 
+
 func _physics_process(delta: float) -> void:
 	if not "--xrsim-automated-tests" in OS.get_cmdline_user_args():
 		# When we're running tests via the XR Simulator, we don't want this

--- a/samples/meta-space-warp-sample/main.gd
+++ b/samples/meta-space-warp-sample/main.gd
@@ -21,6 +21,7 @@ var countdown_to_check_space_warp_enabled: int = 3
 @onready var gpu_particles_3d_2: GPUParticles3D = $GPUParticles3D2
 @onready var cpu_particles_3d_2: CPUParticles3D = $CPUParticles3D2
 
+
 func _ready() -> void:
 	super._ready()
 	right_hand.connect("button_pressed", _on_right_hand_button_pressed)

--- a/samples/meta-space-warp-sample/moving_cube.gd
+++ b/samples/meta-space-warp-sample/moving_cube.gd
@@ -1,5 +1,6 @@
 extends MeshInstance3D
 
+
 func _process(delta: float) -> void:
 	if not "--xrsim-automated-tests" in OS.get_cmdline_user_args():
 		# When we're running tests via the XR Simulator, we don't want this

--- a/samples/meta-space-warp-sample/multi_mesh_move.gd
+++ b/samples/meta-space-warp-sample/multi_mesh_move.gd
@@ -2,6 +2,7 @@ extends MultiMeshInstance3D
 
 @export var direction: Vector3 = Vector3(1, 0, 0)
 
+
 func _process(delta: float) -> void:
 	if not "--xrsim-automated-tests" in OS.get_cmdline_user_args():
 		# When we're running tests via the XR Simulator, we don't want this

--- a/samples/meta-space-warp-sample/start_xr.gd
+++ b/samples/meta-space-warp-sample/start_xr.gd
@@ -8,17 +8,18 @@ signal focus_lost
 signal focus_gained
 signal pose_recentered
 
-@export var maximum_refresh_rate : int = 90
+@export var maximum_refresh_rate: int = 90
 
-var xr_interface : OpenXRInterface
+var xr_interface: OpenXRInterface
 var xr_is_focussed = false
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	xr_interface = XRServer.find_interface("OpenXR")
 	if xr_interface and xr_interface.is_initialized():
 		print("OpenXR instantiated successfully.")
-		var vp : Viewport = get_viewport()
+		var vp: Viewport = get_viewport()
 
 		# Enable XR on our viewport
 		vp.use_xr = true
@@ -55,7 +56,7 @@ func _on_openxr_session_begun() -> void:
 
 	# See if we have a better refresh rate available
 	var new_rate = current_refresh_rate
-	var available_rates : Array = xr_interface.get_available_display_refresh_rates()
+	var available_rates: Array = xr_interface.get_available_display_refresh_rates()
 	if available_rates.size() == 0:
 		print("OpenXR: Target does not support refresh rate extension")
 	elif available_rates.size() == 1:


### PR DESCRIPTION
This uses gdformat (from [gdtoolkit](https://github.com/Scony/godot-gdscript-toolkit)) in CI: if things look good tests should pass; if not, then it'll show a patch with the necessary changes

~~NOTE: This first push should fail - I want to test that failure works :-) but I'll fix in a subsequent push~~

