### PR TITLE
Only add the global shader uniforms for Meta environment depth when it's enabled

### DIFF
--- a/plugin/src/main/cpp/extensions/openxr_meta_environment_depth_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_meta_environment_depth_extension_wrapper.cpp
@@ -545,16 +545,41 @@ static void create_shader_global_uniform(const String &p_name, RenderingServer::
 	}
 }
 
-void OpenXRMetaEnvironmentDepthExtensionWrapper::setup_global_uniforms() {
-	if (already_setup_global_uniforms) {
-		return;
+static void remove_shader_global_uniform(const String &p_name, RenderingServer *p_rendering_server, ProjectSettings *p_project_settings) {
+	String setting_name = "shader_globals/" + p_name;
+	if (p_project_settings->has_setting(setting_name)) {
+		p_rendering_server->global_shader_parameter_remove(p_name);
+		p_project_settings->clear(setting_name);
 	}
+}
 
+void OpenXRMetaEnvironmentDepthExtensionWrapper::setup_global_uniforms() {
 	RenderingServer *rs = RenderingServer::get_singleton();
 	ERR_FAIL_NULL(rs);
 
 	ProjectSettings *project_settings = ProjectSettings::get_singleton();
 	ERR_FAIL_NULL(project_settings);
+
+	bool enabled = project_settings->get_setting_with_override("xr/openxr/extensions/meta/environment_depth");
+
+	if (already_setup_global_uniforms) {
+		if (!enabled) {
+			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_AVAILABLE_NAME, rs, project_settings);
+			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_TEXTURE_NAME, rs, project_settings);
+			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_TEXEL_SIZE_NAME, rs, project_settings);
+			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_PROJECTION_VIEW_LEFT_NAME, rs, project_settings);
+			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_PROJECTION_VIEW_RIGHT_NAME, rs, project_settings);
+			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_INV_PROJECTION_VIEW_LEFT_NAME, rs, project_settings);
+			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_INV_PROJECTION_VIEW_RIGHT_NAME, rs, project_settings);
+			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_FROM_CAMERA_PROJECTION_LEFT_NAME, rs, project_settings);
+			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_FROM_CAMERA_PROJECTION_RIGHT_NAME, rs, project_settings);
+			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_TO_CAMERA_PROJECTION_LEFT_NAME, rs, project_settings);
+			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_TO_CAMERA_PROJECTION_RIGHT_NAME, rs, project_settings);
+
+			already_setup_global_uniforms = false;
+		}
+		return;
+	}
 
 	Engine *engine = Engine::get_singleton();
 	ERR_FAIL_NULL(engine);

--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -357,7 +357,9 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 
 			// Only works with Godot 4.5 or later.
 			if (godot::internal::godot_version.minor >= 5) {
-				callable_mp(OpenXRMetaEnvironmentDepthExtensionWrapper::get_singleton(), &OpenXRMetaEnvironmentDepthExtensionWrapper::setup_global_uniforms).call_deferred();
+				Callable meta_environment_depth_setup_global_uniforms = callable_mp(OpenXRMetaEnvironmentDepthExtensionWrapper::get_singleton(), &OpenXRMetaEnvironmentDepthExtensionWrapper::setup_global_uniforms);
+				meta_environment_depth_setup_global_uniforms.call_deferred();
+				ProjectSettings::get_singleton()->connect("settings_changed", meta_environment_depth_setup_global_uniforms);
 			}
 		} break;
 


### PR DESCRIPTION
Fixes https://github.com/GodotVR/godot_openxr_vendors/issues/376

This PR should make it so that the global shader uniforms for Meta environment depth are only added when it's enabled.

It should also automatically remove the uniforms when disabling it in Project Settings in the editor.