### PR TITLE
Fix missing shader uniform and Godot version in `project.godot` for meta-scene-sample

### DIFF
--- a/samples/meta-scene-sample/project.godot
+++ b/samples/meta-scene-sample/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Meta Scene Sample"
 run/main_scene="res://main.tscn"
-config/features=PackedStringArray("4.5", "GL Compatibility")
+config/features=PackedStringArray("4.4", "GL Compatibility")
 config/icon="res://icon.svg"
 
 [layer_names]
@@ -68,6 +68,10 @@ META_ENVIRONMENT_DEPTH_TO_CAMERA_PROJECTION_LEFT={
 META_ENVIRONMENT_DEPTH_TO_CAMERA_PROJECTION_RIGHT={
 "type": "mat4",
 "value": Projection(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)
+}
+META_ENVIRONMENT_DEPTH_TEXEL_SIZE={
+"type": "vec2",
+"value": Vector2(0, 0)
 }
 
 [xr]


### PR DESCRIPTION
I noticed that in the `project.godot` for meta-scene-sample had some issues:

- The `META_ENVIRONMENT_DEPTH_TEXEL_SIZE` global shader uniform was missing: this shouldn't cause problems on Godot 4.5 with the latest `master` of this extension, because it should automatically add the uniform when you open the project. However, on Godot 4.4 or with an older version of this extension, it'll cause one of the shaders in the project to fail to compile. This may be part of the confusion caused on https://github.com/GodotVR/godot_openxr_vendors/issues/372
- This project should work on both Godot 4.4 and 4.5, so, ideally, the version listed in the `project.godot` should be `"4.4"`