### PR TITLE
Add OpenXR META colocation discovery extension support

### DIFF
--- a/doc_classes/OpenXRMetaColocationDiscoveryExtensionWrapper.xml
+++ b/doc_classes/OpenXRMetaColocationDiscoveryExtensionWrapper.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRMetaColocationDiscoveryExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Wraps the [code]XR_META_colocation_discovery[/code] extension.
+	</brief_description>
+	<description>
+		Wraps the [code]XR_META_colocation_discovery[/code] extension which enables nearby device discovery for colocated multiplayer experiences on Meta Quest devices.
+		This extension allows devices running the same application to discover each other via Bluetooth without requiring manual lobby selection or network configuration.
+		[b]Note:[/b] This extension is only supported on Meta Quest devices and requires the colocation_discovery extension to be enabled in Project Settings under [code]xr/openxr/extensions/meta/colocation_discovery[/code].
+		[codeblock]
+		# Check if colocation discovery is supported
+		if OpenXRMetaColocationDiscoveryExtensionWrapper.is_colocation_discovery_supported():
+		    # Start advertising your session
+		    var session_data = JSON.stringify({"session_id": "my_session", "host": "Player1"}).to_utf8_buffer()
+		    OpenXRMetaColocationDiscoveryExtensionWrapper.start_advertisement(session_data)
+
+		    # Or start discovering nearby sessions
+		    OpenXRMetaColocationDiscoveryExtensionWrapper.start_discovery()
+
+		# Connect to signals
+		OpenXRMetaColocationDiscoveryExtensionWrapper.openxr_meta_colocation_discovery_discovery_result.connect(_on_discovery_result)
+
+		func _on_discovery_result(advertisement_uuid: String, data: PackedByteArray):
+		    var session_info = JSON.parse_string(data.get_string_from_utf8())
+		    print("Found session: ", session_info)
+		[/codeblock]
+	</description>
+	<tutorials>
+		<link title="XR_META_colocation_discovery specification">https://registry.khronos.org/OpenXR/specs/1.1/html/xrspec.html#XR_META_colocation_discovery</link>
+	</tutorials>
+	<methods>
+		<method name="is_colocation_discovery_supported" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the colocation discovery extension is supported on the current device, [code]false[/code] otherwise.
+				This should be checked before attempting to use advertisement or discovery features.
+			</description>
+		</method>
+		<method name="start_advertisement">
+			<return type="bool" />
+			<param index="0" name="buffer" type="PackedByteArray" />
+			<description>
+				Starts advertising the local session to nearby devices. The [param buffer] contains custom session data (max 1024 bytes) that will be transmitted to discovering devices.
+				Typically this data contains session information encoded as JSON, such as session ID, host name, and max players.
+				Returns [code]true[/code] if the advertisement request was successfully initiated, [code]false[/code] otherwise.
+				Listen to the [signal openxr_meta_colocation_discovery_advertisement_started] signal to know when advertising actually begins, or [signal openxr_meta_colocation_discovery_advertisement_failed] if it fails.
+				[b]Note:[/b] Only one advertisement can be active at a time. Call [method stop_advertisement] first if already advertising.
+			</description>
+		</method>
+		<method name="start_discovery">
+			<return type="bool" />
+			<description>
+				Starts discovering nearby advertised sessions. Returns [code]true[/code] if the discovery request was successfully initiated, [code]false[/code] otherwise.
+				Listen to the [signal openxr_meta_colocation_discovery_discovery_started] signal to know when discovery actually begins, and [signal openxr_meta_colocation_discovery_discovery_result] for each discovered session.
+				[b]Note:[/b] Only one discovery operation can be active at a time. Call [method stop_discovery] first if already discovering.
+			</description>
+		</method>
+		<method name="stop_advertisement">
+			<return type="bool" />
+			<description>
+				Stops the current advertisement. Returns [code]true[/code] if the stop request was successfully initiated, [code]false[/code] otherwise.
+				Listen to the [signal openxr_meta_colocation_discovery_advertisement_stopped] signal to know when advertising actually stops.
+			</description>
+		</method>
+		<method name="stop_discovery">
+			<return type="bool" />
+			<description>
+				Stops the current discovery operation. Returns [code]true[/code] if the stop request was successfully initiated, [code]false[/code] otherwise.
+				Listen to the [signal openxr_meta_colocation_discovery_discovery_stopped] signal to know when discovery actually stops.
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="openxr_meta_colocation_discovery_advertisement_complete">
+			<description>
+				Emitted when advertisement is stopped by the OpenXR runtime (not by user request).
+			</description>
+		</signal>
+		<signal name="openxr_meta_colocation_discovery_advertisement_failed">
+			<param index="0" name="error_code" type="int" />
+			<description>
+				Emitted when an advertisement operation fails. The [param error_code] contains the OpenXR error code.
+			</description>
+		</signal>
+		<signal name="openxr_meta_colocation_discovery_advertisement_started">
+			<param index="0" name="advertisement_uuid" type="String" />
+			<description>
+				Emitted when advertisement successfully starts. The [param advertisement_uuid] uniquely identifies this advertisement session.
+			</description>
+		</signal>
+		<signal name="openxr_meta_colocation_discovery_advertisement_stopped">
+			<description>
+				Emitted when advertisement is successfully stopped by user request via [method stop_advertisement].
+			</description>
+		</signal>
+		<signal name="openxr_meta_colocation_discovery_discovery_complete">
+			<description>
+				Emitted when discovery completes successfully.
+			</description>
+		</signal>
+		<signal name="openxr_meta_colocation_discovery_discovery_failed">
+			<param index="0" name="error_code" type="int" />
+			<description>
+				Emitted when a discovery operation fails. The [param error_code] contains the OpenXR error code.
+			</description>
+		</signal>
+		<signal name="openxr_meta_colocation_discovery_discovery_result">
+			<param index="0" name="advertisement_uuid" type="String" />
+			<param index="1" name="data" type="PackedByteArray" />
+			<description>
+				Emitted when a nearby advertised session is discovered. The [param advertisement_uuid] identifies the discovered session, and [param data] contains the custom session data that was passed to [method start_advertisement] by the advertising device.
+				Parse the [param data] (typically as JSON) to get session information such as session ID, host name, and available player slots.
+			</description>
+		</signal>
+		<signal name="openxr_meta_colocation_discovery_discovery_started">
+			<description>
+				Emitted when discovery successfully starts.
+			</description>
+		</signal>
+		<signal name="openxr_meta_colocation_discovery_discovery_stopped">
+			<description>
+				Emitted when discovery is successfully stopped by user request via [method stop_discovery].
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/docs/make_rst.py
+++ b/docs/make_rst.py
@@ -105,6 +105,7 @@ CORE_TYPES: List[str] = [
     "MeshInstance3D",
     "Node3D",
     "Object",
+    "PackedByteArray",
     "PackedScene",
     "PackedStringArray",
     "PackedVector2Array",

--- a/plugin/src/main/cpp/export/meta_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/meta_export_plugin.cpp
@@ -420,6 +420,11 @@ String MetaEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 		contents += "    <uses-permission android:name=\"com.oculus.permission.USE_SCENE\" />\n";
 	}
 
+	// Check for colocation discovery
+	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/colocation_discovery")) {
+		contents += "    <uses-permission android:name=\"com.oculus.permission.USE_COLOCATION_DISCOVERY_API\" />\n";
+	}
+
 // @todo GH Issue 304: Remove check for meta headers when feature becomes part of OpenXR spec.
 #ifdef META_HEADERS_ENABLED
 	// Check for boundary visibility

--- a/plugin/src/main/cpp/extensions/openxr_meta_colocation_discovery_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_meta_colocation_discovery_extension_wrapper.cpp
@@ -1,0 +1,343 @@
+/**************************************************************************/
+/*  openxr_meta_colocation_discovery.cpp                                 */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "extensions/openxr_meta_colocation_discovery_extension_wrapper.h"
+
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+OpenXRMetaColocationDiscoveryExtensionWrapper *OpenXRMetaColocationDiscoveryExtensionWrapper::singleton = nullptr;
+
+OpenXRMetaColocationDiscoveryExtensionWrapper *OpenXRMetaColocationDiscoveryExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRMetaColocationDiscoveryExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRMetaColocationDiscoveryExtensionWrapper::OpenXRMetaColocationDiscoveryExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRMetaColocationDiscoveryExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_META_COLOCATION_DISCOVERY_EXTENSION_NAME] = &meta_colocation_discovery_ext;
+	singleton = this;
+}
+
+OpenXRMetaColocationDiscoveryExtensionWrapper::~OpenXRMetaColocationDiscoveryExtensionWrapper() {
+	cleanup();
+	singleton = nullptr;
+}
+
+godot::Dictionary OpenXRMetaColocationDiscoveryExtensionWrapper::_get_requested_extensions() {
+	godot::Dictionary result;
+	for (auto ext : request_extensions) {
+		godot::String key = ext.first;
+		uint64_t value = reinterpret_cast<uint64_t>(ext.second);
+		result[key] = (godot::Variant)value;
+	}
+	return result;
+}
+
+void OpenXRMetaColocationDiscoveryExtensionWrapper::_on_instance_created(uint64_t instance) {
+	if (!meta_colocation_discovery_ext) {
+		return;
+	}
+
+	if (!initialize_extension((XrInstance)instance)) {
+		meta_colocation_discovery_ext = false;
+	}
+}
+
+uint64_t OpenXRMetaColocationDiscoveryExtensionWrapper::_set_system_properties_and_get_next_pointer(void *p_next_pointer) {
+	if (meta_colocation_discovery_ext) {
+		colocation_discovery_properties.next = p_next_pointer;
+		p_next_pointer = &colocation_discovery_properties;
+	}
+
+	return reinterpret_cast<uint64_t>(p_next_pointer);
+}
+
+bool OpenXRMetaColocationDiscoveryExtensionWrapper::initialize_extension(const XrInstance instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrStartColocationAdvertisementMETA);
+	GDEXTENSION_INIT_XR_FUNC_V(xrStopColocationAdvertisementMETA);
+	GDEXTENSION_INIT_XR_FUNC_V(xrStartColocationDiscoveryMETA);
+	GDEXTENSION_INIT_XR_FUNC_V(xrStopColocationDiscoveryMETA);
+
+	return true;
+}
+
+void OpenXRMetaColocationDiscoveryExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+bool OpenXRMetaColocationDiscoveryExtensionWrapper::_on_event_polled(const void *event) {
+	if (!meta_colocation_discovery_ext) {
+		return false;
+	}
+
+	const XrEventDataBuffer *event_buffer = (const XrEventDataBuffer *)event;
+
+	switch (event_buffer->type) {
+		case XR_TYPE_EVENT_DATA_START_COLOCATION_ADVERTISEMENT_COMPLETE_META: {
+			on_start_advertisement_complete((const XrEventDataStartColocationAdvertisementCompleteMETA *)event);
+			return true;
+		}
+		case XR_TYPE_EVENT_DATA_STOP_COLOCATION_ADVERTISEMENT_COMPLETE_META: {
+			on_stop_advertisement_complete((const XrEventDataStopColocationAdvertisementCompleteMETA *)event);
+			return true;
+		}
+		case XR_TYPE_EVENT_DATA_COLOCATION_ADVERTISEMENT_COMPLETE_META: {
+			on_advertisement_complete((const XrEventDataColocationAdvertisementCompleteMETA *)event);
+			return true;
+		}
+		case XR_TYPE_EVENT_DATA_START_COLOCATION_DISCOVERY_COMPLETE_META: {
+			on_start_discovery_complete((const XrEventDataStartColocationDiscoveryCompleteMETA *)event);
+			return true;
+		}
+		case XR_TYPE_EVENT_DATA_COLOCATION_DISCOVERY_RESULT_META: {
+			on_discovery_result((const XrEventDataColocationDiscoveryResultMETA *)event);
+			return true;
+		}
+		case XR_TYPE_EVENT_DATA_COLOCATION_DISCOVERY_COMPLETE_META: {
+			on_discovery_complete((const XrEventDataColocationDiscoveryCompleteMETA *)event);
+			return true;
+		}
+		case XR_TYPE_EVENT_DATA_STOP_COLOCATION_DISCOVERY_COMPLETE_META: {
+			on_stop_discovery_complete((const XrEventDataStopColocationDiscoveryCompleteMETA *)event);
+			return true;
+		}
+		default:
+			return false;
+	}
+}
+
+bool OpenXRMetaColocationDiscoveryExtensionWrapper::is_colocation_discovery_supported() const {
+	return meta_colocation_discovery_ext && colocation_discovery_properties.supportsColocationDiscovery;
+}
+
+bool OpenXRMetaColocationDiscoveryExtensionWrapper::start_advertisement(const PackedByteArray &p_buffer) {
+	ERR_FAIL_COND_V_MSG(!meta_colocation_discovery_ext, false, "XR_META_colocation_discovery extension is not enabled");
+	ERR_FAIL_COND_V_MSG(p_buffer.size() > XR_MAX_COLOCATION_DISCOVERY_BUFFER_SIZE_META, false,
+			vformat("Buffer size %d exceeds maximum size of %d bytes", p_buffer.size(), XR_MAX_COLOCATION_DISCOVERY_BUFFER_SIZE_META));
+
+	if (is_advertising) {
+		UtilityFunctions::push_warning("Already advertising, stop current advertisement first");
+		return false;
+	}
+
+	XrColocationAdvertisementStartInfoMETA start_info = {
+		XR_TYPE_COLOCATION_ADVERTISEMENT_START_INFO_META, // type
+		nullptr, // next
+		(uint32_t)p_buffer.size(), // bufferSize
+		(uint8_t *)p_buffer.ptr() // buffer
+	};
+
+	XrAsyncRequestIdFB request_id;
+	XrResult result = xrStartColocationAdvertisementMETA(SESSION, &start_info, &request_id);
+
+	if (XR_SUCCEEDED(result)) {
+		return true;
+	} else {
+		UtilityFunctions::push_error(vformat("Failed to start colocation advertisement: %d", result));
+		return false;
+	}
+}
+
+bool OpenXRMetaColocationDiscoveryExtensionWrapper::stop_advertisement() {
+	ERR_FAIL_COND_V_MSG(!meta_colocation_discovery_ext, false, "XR_META_colocation_discovery extension is not enabled");
+
+	if (!is_advertising) {
+		UtilityFunctions::push_warning("Not currently advertising");
+		return false;
+	}
+
+	XrColocationAdvertisementStopInfoMETA stop_info = {
+		XR_TYPE_COLOCATION_ADVERTISEMENT_STOP_INFO_META, // type
+		nullptr // next
+	};
+
+	XrAsyncRequestIdFB request_id;
+	XrResult result = xrStopColocationAdvertisementMETA(SESSION, &stop_info, &request_id);
+
+	if (XR_SUCCEEDED(result)) {
+		return true;
+	} else {
+		UtilityFunctions::push_error(vformat("Failed to stop colocation advertisement: %d", result));
+		return false;
+	}
+}
+
+bool OpenXRMetaColocationDiscoveryExtensionWrapper::start_discovery() {
+	ERR_FAIL_COND_V_MSG(!meta_colocation_discovery_ext, false, "XR_META_colocation_discovery extension is not enabled");
+
+	if (is_discovering) {
+		UtilityFunctions::push_warning("Already discovering, stop current discovery first");
+		return false;
+	}
+
+	XrColocationDiscoveryStartInfoMETA start_info = {
+		XR_TYPE_COLOCATION_DISCOVERY_START_INFO_META, // type
+		nullptr // next
+	};
+
+	XrAsyncRequestIdFB request_id;
+	XrResult result = xrStartColocationDiscoveryMETA(SESSION, &start_info, &request_id);
+
+	if (XR_SUCCEEDED(result)) {
+		return true;
+	} else {
+		UtilityFunctions::push_error(vformat("Failed to start colocation discovery: %d", result));
+		return false;
+	}
+}
+
+bool OpenXRMetaColocationDiscoveryExtensionWrapper::stop_discovery() {
+	ERR_FAIL_COND_V_MSG(!meta_colocation_discovery_ext, false, "XR_META_colocation_discovery extension is not enabled");
+
+	if (!is_discovering) {
+		UtilityFunctions::push_warning("Not currently discovering");
+		return false;
+	}
+
+	XrColocationDiscoveryStopInfoMETA stop_info = {
+		XR_TYPE_COLOCATION_DISCOVERY_STOP_INFO_META, // type
+		nullptr // next
+	};
+
+	XrAsyncRequestIdFB request_id;
+	XrResult result = xrStopColocationDiscoveryMETA(SESSION, &stop_info, &request_id);
+
+	if (XR_SUCCEEDED(result)) {
+		return true;
+	} else {
+		UtilityFunctions::push_error(vformat("Failed to stop colocation discovery: %d", result));
+		return false;
+	}
+}
+
+void OpenXRMetaColocationDiscoveryExtensionWrapper::on_start_advertisement_complete(const XrEventDataStartColocationAdvertisementCompleteMETA *event) {
+	if (XR_SUCCEEDED(event->result)) {
+		is_advertising = true;
+		String uuid_str = OpenXRUtilities::uuid_to_string_name(event->advertisementUuid);
+		emit_signal("openxr_meta_colocation_discovery_advertisement_started", uuid_str);
+	} else {
+		UtilityFunctions::push_error(vformat("Failed to start advertisement: %d", event->result));
+		emit_signal("openxr_meta_colocation_discovery_advertisement_failed", (int)event->result);
+	}
+}
+
+void OpenXRMetaColocationDiscoveryExtensionWrapper::on_stop_advertisement_complete(const XrEventDataStopColocationAdvertisementCompleteMETA *event) {
+	if (XR_SUCCEEDED(event->result)) {
+		is_advertising = false;
+		emit_signal("openxr_meta_colocation_discovery_advertisement_stopped");
+	} else {
+		UtilityFunctions::push_error(vformat("Failed to stop advertisement: %d", event->result));
+		emit_signal("openxr_meta_colocation_discovery_advertisement_failed", (int)event->result);
+	}
+}
+
+void OpenXRMetaColocationDiscoveryExtensionWrapper::on_advertisement_complete(const XrEventDataColocationAdvertisementCompleteMETA *event) {
+	is_advertising = false;
+	if (XR_SUCCEEDED(event->result)) {
+		emit_signal("openxr_meta_colocation_discovery_advertisement_complete");
+	} else {
+		UtilityFunctions::push_error(vformat("Advertisement ended with error: %d", event->result));
+		emit_signal("openxr_meta_colocation_discovery_advertisement_failed", (int)event->result);
+	}
+}
+
+void OpenXRMetaColocationDiscoveryExtensionWrapper::on_start_discovery_complete(const XrEventDataStartColocationDiscoveryCompleteMETA *event) {
+	if (XR_SUCCEEDED(event->result)) {
+		is_discovering = true;
+		emit_signal("openxr_meta_colocation_discovery_discovery_started");
+	} else {
+		UtilityFunctions::push_error(vformat("Failed to start discovery: %d", event->result));
+		emit_signal("openxr_meta_colocation_discovery_discovery_failed", (int)event->result);
+	}
+}
+
+void OpenXRMetaColocationDiscoveryExtensionWrapper::on_discovery_result(const XrEventDataColocationDiscoveryResultMETA *event) {
+	String uuid_str = OpenXRUtilities::uuid_to_string_name(event->advertisementUuid);
+
+	PackedByteArray buffer;
+	buffer.resize(event->bufferSize);
+	memcpy(buffer.ptrw(), event->buffer, event->bufferSize);
+
+	emit_signal("openxr_meta_colocation_discovery_discovery_result", uuid_str, buffer);
+}
+
+void OpenXRMetaColocationDiscoveryExtensionWrapper::on_discovery_complete(const XrEventDataColocationDiscoveryCompleteMETA *event) {
+	is_discovering = false;
+	if (XR_SUCCEEDED(event->result)) {
+		emit_signal("openxr_meta_colocation_discovery_discovery_complete");
+	} else {
+		UtilityFunctions::push_error(vformat("Discovery ended with error: %d", event->result));
+		emit_signal("openxr_meta_colocation_discovery_discovery_failed", (int)event->result);
+	}
+}
+
+void OpenXRMetaColocationDiscoveryExtensionWrapper::on_stop_discovery_complete(const XrEventDataStopColocationDiscoveryCompleteMETA *event) {
+	if (XR_SUCCEEDED(event->result)) {
+		is_discovering = false;
+		emit_signal("openxr_meta_colocation_discovery_discovery_stopped");
+	} else {
+		UtilityFunctions::push_error(vformat("Failed to stop discovery: %d", event->result));
+		emit_signal("openxr_meta_colocation_discovery_discovery_failed", (int)event->result);
+	}
+}
+
+void OpenXRMetaColocationDiscoveryExtensionWrapper::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_colocation_discovery_supported"), &OpenXRMetaColocationDiscoveryExtensionWrapper::is_colocation_discovery_supported);
+	ClassDB::bind_method(D_METHOD("start_advertisement", "buffer"), &OpenXRMetaColocationDiscoveryExtensionWrapper::start_advertisement);
+	ClassDB::bind_method(D_METHOD("stop_advertisement"), &OpenXRMetaColocationDiscoveryExtensionWrapper::stop_advertisement);
+	ClassDB::bind_method(D_METHOD("start_discovery"), &OpenXRMetaColocationDiscoveryExtensionWrapper::start_discovery);
+	ClassDB::bind_method(D_METHOD("stop_discovery"), &OpenXRMetaColocationDiscoveryExtensionWrapper::stop_discovery);
+
+	// Signals
+	ADD_SIGNAL(MethodInfo("openxr_meta_colocation_discovery_advertisement_started", PropertyInfo(Variant::STRING, "advertisement_uuid")));
+	ADD_SIGNAL(MethodInfo("openxr_meta_colocation_discovery_advertisement_stopped"));
+	ADD_SIGNAL(MethodInfo("openxr_meta_colocation_discovery_advertisement_complete"));
+	ADD_SIGNAL(MethodInfo("openxr_meta_colocation_discovery_advertisement_failed", PropertyInfo(Variant::INT, "error_code")));
+
+	ADD_SIGNAL(MethodInfo("openxr_meta_colocation_discovery_discovery_started"));
+	ADD_SIGNAL(MethodInfo("openxr_meta_colocation_discovery_discovery_result",
+			PropertyInfo(Variant::STRING, "advertisement_uuid"),
+			PropertyInfo(Variant::PACKED_BYTE_ARRAY, "data")));
+	ADD_SIGNAL(MethodInfo("openxr_meta_colocation_discovery_discovery_complete"));
+	ADD_SIGNAL(MethodInfo("openxr_meta_colocation_discovery_discovery_stopped"));
+	ADD_SIGNAL(MethodInfo("openxr_meta_colocation_discovery_discovery_failed", PropertyInfo(Variant::INT, "error_code")));
+}
+
+void OpenXRMetaColocationDiscoveryExtensionWrapper::cleanup() {
+	meta_colocation_discovery_ext = false;
+	is_advertising = false;
+	is_discovering = false;
+}

--- a/plugin/src/main/cpp/include/extensions/openxr_meta_colocation_discovery_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_meta_colocation_discovery_extension_wrapper.h
@@ -1,0 +1,113 @@
+/**************************************************************************/
+/*  openxr_meta_colocation_discovery_extension_wrapper.h                  */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <openxr/openxr.h>
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <godot_cpp/templates/hash_map.hpp>
+#include <map>
+
+#include "util.h"
+
+using namespace godot;
+
+// Wrapper for the XR_META_colocation_discovery extension.
+class OpenXRMetaColocationDiscoveryExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRMetaColocationDiscoveryExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	static OpenXRMetaColocationDiscoveryExtensionWrapper *get_singleton();
+
+	OpenXRMetaColocationDiscoveryExtensionWrapper();
+	~OpenXRMetaColocationDiscoveryExtensionWrapper();
+
+	godot::Dictionary _get_requested_extensions() override;
+
+	void _on_instance_created(uint64_t instance) override;
+	uint64_t _set_system_properties_and_get_next_pointer(void *p_next_pointer) override;
+	void _on_instance_destroyed() override;
+	bool _on_event_polled(const void *event) override;
+
+	bool is_colocation_discovery_supported() const;
+
+	bool start_advertisement(const PackedByteArray &p_buffer);
+	bool stop_advertisement();
+	bool start_discovery();
+	bool stop_discovery();
+
+protected:
+	static void _bind_methods();
+
+private:
+	EXT_PROTO_XRRESULT_FUNC3(xrStartColocationAdvertisementMETA,
+			(XrSession), session,
+			(const XrColocationAdvertisementStartInfoMETA *), info,
+			(XrAsyncRequestIdFB *), advertisementRequestId)
+
+	EXT_PROTO_XRRESULT_FUNC3(xrStopColocationAdvertisementMETA,
+			(XrSession), session,
+			(const XrColocationAdvertisementStopInfoMETA *), info,
+			(XrAsyncRequestIdFB *), requestId)
+
+	EXT_PROTO_XRRESULT_FUNC3(xrStartColocationDiscoveryMETA,
+			(XrSession), session,
+			(const XrColocationDiscoveryStartInfoMETA *), info,
+			(XrAsyncRequestIdFB *), discoveryRequestId)
+
+	EXT_PROTO_XRRESULT_FUNC3(xrStopColocationDiscoveryMETA,
+			(XrSession), session,
+			(const XrColocationDiscoveryStopInfoMETA *), info,
+			(XrAsyncRequestIdFB *), requestId)
+
+	bool initialize_extension(const XrInstance instance);
+	void cleanup();
+
+	void on_start_advertisement_complete(const XrEventDataStartColocationAdvertisementCompleteMETA *event);
+	void on_stop_advertisement_complete(const XrEventDataStopColocationAdvertisementCompleteMETA *event);
+	void on_advertisement_complete(const XrEventDataColocationAdvertisementCompleteMETA *event);
+	void on_start_discovery_complete(const XrEventDataStartColocationDiscoveryCompleteMETA *event);
+	void on_discovery_result(const XrEventDataColocationDiscoveryResultMETA *event);
+	void on_discovery_complete(const XrEventDataColocationDiscoveryCompleteMETA *event);
+	void on_stop_discovery_complete(const XrEventDataStopColocationDiscoveryCompleteMETA *event);
+
+	static OpenXRMetaColocationDiscoveryExtensionWrapper *singleton;
+
+	std::map<godot::String, bool *> request_extensions;
+	bool meta_colocation_discovery_ext = false;
+
+	XrSystemColocationDiscoveryPropertiesMETA colocation_discovery_properties = {
+		XR_TYPE_SYSTEM_COLOCATION_DISCOVERY_PROPERTIES_META, // type
+		nullptr, // next
+		XR_FALSE // supportsColocationDiscovery
+	};
+
+	bool is_advertising = false;
+	bool is_discovering = false;
+};

--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -73,6 +73,7 @@
 #include "extensions/openxr_htc_facial_tracking_extension_wrapper.h"
 #include "extensions/openxr_htc_passthrough_extension_wrapper.h"
 #include "extensions/openxr_meta_boundary_visibility_extension_wrapper.h"
+#include "extensions/openxr_meta_colocation_discovery_extension_wrapper.h"
 #include "extensions/openxr_meta_environment_depth_extension_wrapper.h"
 #include "extensions/openxr_meta_headset_id_extension_wrapper.h"
 #include "extensions/openxr_meta_performance_metrics_extension_wrapper.h"
@@ -157,6 +158,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			GDREGISTER_CLASS(OpenXRMetaRecommendedLayerResolutionExtensionWrapper);
 			GDREGISTER_CLASS(OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper);
 			GDREGISTER_CLASS(OpenXRMetaHeadsetIDExtensionWrapper);
+			GDREGISTER_CLASS(OpenXRMetaColocationDiscoveryExtensionWrapper);
 			GDREGISTER_CLASS(OpenXRMetaSpatialEntityMeshExtensionWrapper);
 			GDREGISTER_CLASS(OpenXRFbSceneExtensionWrapper);
 			GDREGISTER_CLASS(OpenXRFbFaceTrackingExtensionWrapper);
@@ -269,6 +271,10 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			}
 #endif // META_HEADERS_ENABLED
 
+			if (_get_bool_project_setting("xr/openxr/extensions/meta/colocation_discovery")) {
+				_register_extension_with_openxr(OpenXRMetaColocationDiscoveryExtensionWrapper::get_singleton());
+			}
+
 			if (_get_bool_project_setting("xr/openxr/extensions/htc/face_tracking")) {
 				_register_extension_with_openxr(OpenXRHtcFacialTrackingExtensionWrapper::get_singleton());
 			}
@@ -309,6 +315,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			_register_extension_as_singleton(OpenXRFbHandTrackingCapsulesExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRMetaHeadsetIDExtensionWrapper::get_singleton());
+			_register_extension_as_singleton(OpenXRMetaColocationDiscoveryExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRFbBodyTrackingExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRHtcFacialTrackingExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRHtcPassthroughExtensionWrapper::get_singleton());
@@ -462,6 +469,7 @@ void add_plugin_project_settings() {
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/composition_layer_settings", true);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/dynamic_resolution", true);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/headset_id", false);
+	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/colocation_discovery", false);
 
 	// Only works with Godot 4.5 or later.
 	if (godot::internal::godot_version.minor >= 5) {


### PR DESCRIPTION
Introduces the OpenXRMetaColocationDiscovery class to support the XR_META_colocation_discovery extension, including registration, project setting, and Android permission handling. This enables colocation advertisement and discovery features for supported devices and exposes related methods and signals to Godot XR.