### PR TITLE
Fix the set of features supported by the plugin to include Android XR

### DIFF
--- a/config.gradle
+++ b/config.gradle
@@ -21,7 +21,7 @@ ext {
 
     // Parse the release version from the gradle project properties (e.g: -Prelease_version=<version>)
     getReleaseVersion = { ->
-        final String defaultVersion = "4.2.0-stable" // Also update 'plugin/src/main/cpp/include/export/export_plugin.h#PLUGIN_VERSION'
+        final String defaultVersion = "4.2.1-dev" // Also update 'plugin/src/main/cpp/include/export/export_plugin.h#PLUGIN_VERSION'
 
         String releaseVersion = project.hasProperty("release_version") ? project.property("release_version") : defaultVersion
         if (releaseVersion == null || releaseVersion.isEmpty()) {

--- a/plugin/src/main/cpp/include/export/export_plugin.h
+++ b/plugin/src/main/cpp/include/export/export_plugin.h
@@ -40,7 +40,7 @@
 
 using namespace godot;
 
-static const char *PLUGIN_VERSION = "4.2.0-stable"; // Also update 'config.gradle#defaultVersion'
+static const char *PLUGIN_VERSION = "4.2.1-dev"; // Also update 'config.gradle#defaultVersion'
 
 // Set of supported vendors
 static const char *META_VENDOR_NAME = "meta";

--- a/plugin/src/main/java/org/godotengine/openxr/vendors/GodotOpenXR.kt
+++ b/plugin/src/main/java/org/godotengine/openxr/vendors/GodotOpenXR.kt
@@ -67,6 +67,71 @@ class GodotOpenXR(godot: Godot?) : GodotPlugin(godot) {
 				Log.e(TAG, "Unable to load native libraries")
 			}
 		}
+
+		@JvmStatic
+		fun supportsFeature(godot: Godot, featureTag: String): Boolean {
+			val context = godot.context
+			when (featureTag) {
+				"xr_runtime" -> {
+					return isNativeXRDevice(context)
+				}
+
+				ANDROID_XR_OS -> {
+					return isAndroidXRDevice(context)
+				}
+
+				META_HORIZON_OS -> {
+					return isHorizonOSDevice(context)
+				}
+
+				PICO_OS -> {
+					return isPicoOSDevice()
+				}
+
+				EYE_GAZE_INTERACTION_FEATURE_TAG -> {
+					when (BuildConfig.FLAVOR) {
+						ANDROID_XR_VENDOR_NAME -> {
+							val grantedPermissions = godot.getGrantedPermissions()
+							if (grantedPermissions != null) {
+								for (permission in grantedPermissions) {
+									if (ANDROID_XR_EYE_TRACKING_FINE_PERMISSION == permission) {
+										return true
+									}
+								}
+							}
+						}
+
+						META_VENDOR_NAME -> {
+							val grantedPermissions = godot.getGrantedPermissions()
+							if (grantedPermissions != null) {
+								for (permission in grantedPermissions) {
+									if (META_EYE_TRACKING_PERMISSION == permission) {
+										return true
+									}
+								}
+							}
+						}
+
+						PICO_VENDOR_NAME -> {
+							val grantedPermissions = godot.getGrantedPermissions()
+							if (grantedPermissions != null) {
+								for (permission in grantedPermissions) {
+									if (PICO_EYE_TRACKING_PERMISSION == permission) {
+										return true
+									}
+								}
+							}
+						}
+
+						else -> {
+							// Other vendors don't require the permission.
+							return true;
+						}
+					}
+				}
+			}
+			return false
+		}
 	}
 
 	override fun getPluginName() = "GodotOpenXR"
@@ -109,57 +174,6 @@ class GodotOpenXR(godot: Godot?) : GodotPlugin(godot) {
 	}
 
 	override fun supportsFeature(featureTag: String): Boolean {
-		when (featureTag) {
-			META_HORIZON_OS -> {
-				return BuildConfig.FLAVOR == META_VENDOR_NAME || isHorizonOSDevice(context)
-			}
-
-			PICO_OS -> {
-				return BuildConfig.FLAVOR == PICO_VENDOR_NAME || isPicoOSDevice()
-			}
-
-			EYE_GAZE_INTERACTION_FEATURE_TAG -> {
-				when (BuildConfig.FLAVOR) {
-					ANDROID_XR_VENDOR_NAME -> {
-						val grantedPermissions = godot?.getGrantedPermissions()
-						if (grantedPermissions != null) {
-							for (permission in grantedPermissions) {
-								if (ANDROID_XR_EYE_TRACKING_FINE_PERMISSION == permission) {
-									return true
-								}
-							}
-						}
-					}
-
-					META_VENDOR_NAME -> {
-						val grantedPermissions = godot?.getGrantedPermissions()
-						if (grantedPermissions != null) {
-							for (permission in grantedPermissions) {
-								if (META_EYE_TRACKING_PERMISSION == permission) {
-									return true
-								}
-							}
-						}
-					}
-
-					PICO_VENDOR_NAME -> {
-						val grantedPermissions = godot?.getGrantedPermissions()
-						if (grantedPermissions != null) {
-							for (permission in grantedPermissions) {
-								if (PICO_EYE_TRACKING_PERMISSION == permission) {
-									return true
-								}
-							}
-						}
-					}
-
-					else -> {
-						// Other vendors don't require the permission.
-						return true;
-					}
-				}
-			}
-		}
-		return super.supportsFeature(featureTag)
+		return supportsFeature(godot, featureTag) || super.supportsFeature(featureTag)
 	}
 }

--- a/plugin/src/main/java/org/godotengine/openxr/vendors/GodotOpenXRHybridAppInternal.kt
+++ b/plugin/src/main/java/org/godotengine/openxr/vendors/GodotOpenXRHybridAppInternal.kt
@@ -165,4 +165,8 @@ class GodotOpenXRHybridAppInternal(godot: Godot?) : GodotPlugin(godot) {
 	private fun getHybridAppLaunchData(): String {
 		return hybridLaunchData
 	}
+
+	override fun supportsFeature(featureTag: String): Boolean {
+		return GodotOpenXR.supportsFeature(godot, featureTag) || super.supportsFeature(featureTag)
+	}
 }

--- a/plugin/src/main/java/org/godotengine/openxr/vendors/utils/DeviceUtils.kt
+++ b/plugin/src/main/java/org/godotengine/openxr/vendors/utils/DeviceUtils.kt
@@ -39,6 +39,11 @@ import android.os.Build
 
 // Set of supported OS
 /**
+ * Label used to identify the Android XR OS in the Godot engine.
+ */
+const val ANDROID_XR_OS = "androidxr"
+
+/**
  * Label used to identity the Meta Horizon OS in the Godot engine.
  */
 const val META_HORIZON_OS = "horizonos"


### PR DESCRIPTION
This fixes an omission and adds `androidxr` to the set of features supported by this plugin.
In addition, it introduces the `xr_runtime` feature which allows to query if running on a supported xr platform.