### PR TITLE
Don't include the `common` directory in the built addon

### DIFF
--- a/.github/workflows/build-addon-on-push.yml
+++ b/.github/workflows/build-addon-on-push.yml
@@ -235,6 +235,7 @@ jobs:
         run: |
           mkdir asset
           cp -r aar/demo/addons asset
+          rm -rf asset/addons/common
           cp aar/CHANGES.md asset/addons/godotopenxrvendors/GodotOpenXRVendors_CHANGES.md
       - name: Adding vendor licences
         run: |


### PR DESCRIPTION
In our last release, the `common` directory accidentally got included in the built addon.

This _should_ remove it before the addon is bundled up

~~(I'm going to use the CI on this PR to test that it works, so marking as a DRAFT until then)~~