### PR TITLE
Update the ndk version for the github workflows

### DIFF
--- a/.github/workflows/build-addon-on-push.yml
+++ b/.github/workflows/build-addon-on-push.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Android dependencies
         uses: nttld/setup-ndk@v1
         with:
-          ndk-version: r23c
+          ndk-version: r28b
           link-to-sdk: true
         if: matrix.platform == 'android'
       - name: Download Meta OpenXR Preview headers
@@ -177,8 +177,8 @@ jobs:
       - name: Create extension library
         run: |
           cd aar
-          scons platform=${{ matrix.platform }} target=template_debug ${{ matrix.flags }} custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json $SCONS_EXTRA
-          scons platform=${{ matrix.platform }} target=template_release ${{ matrix.flags }} custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json $SCONS_EXTRA
+          scons platform=${{ matrix.platform }} target=template_debug ${{ matrix.flags }} custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json ndk_version="28.1.13356709" $SCONS_EXTRA
+          scons platform=${{ matrix.platform }} target=template_release ${{ matrix.flags }} custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json ndk_version="28.1.13356709" $SCONS_EXTRA
           cd ..
       - name: Save Godot build cache
         uses: ./aar/thirdparty/godot-cpp/.github/actions/godot-cache-save

--- a/.github/workflows/mavencentral-publish.yml
+++ b/.github/workflows/mavencentral-publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Android dependencies
         uses: nttld/setup-ndk@v1
         with:
-          ndk-version: r23c
+          ndk-version: r28b
           link-to-sdk: true
       - name: Install scons
         run: |
@@ -55,10 +55,10 @@ jobs:
         run: |
           # We build with debug symbols which will be stripped by Gradle.
           SCONS_EXTRA="$SCONS_EXTRA debug_symbols=yes"
-          scons platform=android target=template_debug arch=arm64 custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json $SCONS_EXTRA
-          scons platform=android target=template_release arch=arm64 custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json $SCONS_EXTRA
-          scons platform=android target=template_debug arch=x86_64 custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json $SCONS_EXTRA
-          scons platform=android target=template_release arch=x86_64 custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json $SCONS_EXTRA
+          scons platform=android target=template_debug arch=arm64 custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json ndk_version="28.1.13356709" $SCONS_EXTRA
+          scons platform=android target=template_release arch=arm64 custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json ndk_version="28.1.13356709" $SCONS_EXTRA
+          scons platform=android target=template_debug arch=x86_64 custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json ndk_version="28.1.13356709" $SCONS_EXTRA
+          scons platform=android target=template_release arch=x86_64 custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json ndk_version="28.1.13356709" $SCONS_EXTRA
           ./gradlew -Prelease_version=${{ github.ref_name }} build $GRADLE_EXTRA
 
           # Put the unstripped .so files into ZIPs to use for their debug symbols.

--- a/config.gradle
+++ b/config.gradle
@@ -4,9 +4,11 @@ ext {
             compileSdk              : 35,
             minSdk                  : 21,
             targetSdk               : 35,
+            // Update the Java version in the github workflows when this is updated.
             javaVersion             : JavaVersion.VERSION_17,
             nexusPublishVersion     : '1.3.0',
             kotlinVersion           : '2.1.20',
+            // Update the NDK version in the github workflows when this is updated.
             ndkVersion              : '28.1.13356709',
             // Note that 'plugin/src/main/AndroidManifest.xml' should be updated with content
             // from the Khronos OpenXR loader manifest.


### PR DESCRIPTION
Fixes the mismatch between the ndk version used in the manual builds and the ndk version used in the github worflows.

This mismatch was preventing the CI generated builds from being 16-kb page compatible.

Follow-up to https://github.com/GodotVR/godot_openxr_vendors/pull/375