### PR TITLE
Fix crash when using the plugin on Godot 4.4.x

### DIFF
--- a/plugin/src/main/java/org/godotengine/openxr/vendors/GodotOpenXR.kt
+++ b/plugin/src/main/java/org/godotengine/openxr/vendors/GodotOpenXR.kt
@@ -70,7 +70,8 @@ class GodotOpenXR(godot: Godot?) : GodotPlugin(godot) {
 
 		@JvmStatic
 		fun supportsFeature(godot: Godot, featureTag: String): Boolean {
-			val context = godot.context
+			// TODO(v5.x): Switch to `godot.context` when bumping the min Godot supported version to 4.5+
+			val context = godot.getActivity()
 			when (featureTag) {
 				"xr_runtime" -> {
 					return isNativeXRDevice(context)

--- a/plugin/src/main/java/org/godotengine/openxr/vendors/GodotOpenXRHybridAppInternal.kt
+++ b/plugin/src/main/java/org/godotengine/openxr/vendors/GodotOpenXRHybridAppInternal.kt
@@ -35,7 +35,6 @@ import android.content.Intent
 import android.util.Log
 import android.view.View
 import org.godotengine.godot.Godot
-import org.godotengine.godot.GodotActivity.Companion.EXTRA_COMMAND_LINE_PARAMS
 import org.godotengine.godot.GodotHost
 import org.godotengine.godot.plugin.GodotPlugin
 import org.godotengine.godot.plugin.UsedByGodot

--- a/plugin/src/main/java/org/godotengine/openxr/vendors/utils/DeviceUtils.kt
+++ b/plugin/src/main/java/org/godotengine/openxr/vendors/utils/DeviceUtils.kt
@@ -56,14 +56,20 @@ const val PICO_OS = "picoos"
 /**
  * Returns true if running on an Android XR device.
  */
-fun isAndroidXRDevice(context: Context): Boolean {
+fun isAndroidXRDevice(context: Context?): Boolean {
+	if (context == null) {
+		return false
+	}
 	return context.packageManager.hasSystemFeature("android.software.xr.api.openxr")
 }
 
 /**
  * Returns true if running on Meta Horizon OS.
  */
-fun isHorizonOSDevice(context: Context): Boolean {
+fun isHorizonOSDevice(context: Context?): Boolean {
+	if (context == null) {
+		return false
+	}
 	return context.packageManager.hasSystemFeature("oculus.hardware.standalone_vr")
 }
 
@@ -77,6 +83,6 @@ fun isPicoOSDevice(): Boolean {
 /**
  * Returns true if running on a native Android XR device.
  */
-fun isNativeXRDevice(context: Context): Boolean {
+fun isNativeXRDevice(context: Context?): Boolean {
 	return isHorizonOSDevice(context) || isPicoOSDevice() || isAndroidXRDevice(context)
 }

--- a/plugin/src/main/java/org/godotengine/openxr/vendors/utils/HybridAppUtils.kt
+++ b/plugin/src/main/java/org/godotengine/openxr/vendors/utils/HybridAppUtils.kt
@@ -37,7 +37,6 @@ package org.godotengine.openxr.vendors.utils
 import android.content.Intent
 import android.util.Base64
 import android.util.Log
-import org.godotengine.godot.GodotActivity.Companion.EXTRA_COMMAND_LINE_PARAMS
 import org.godotengine.godot.GodotLib
 
 private const val TAG = "HybridAppUtils"
@@ -62,6 +61,7 @@ enum class HybridMode(private val nativeValue: Int) {
 	}
 }
 
+internal val EXTRA_COMMAND_LINE_PARAMS = "command_line_params"
 const val HYBRID_DATA_ARG = "--openxr-hybrid-data"
 
 const val HYBRID_APP_FEATURE = "godot_openxr_hybrid_app"


### PR DESCRIPTION
The crashes were due to the use of new Godot 4.5+ apis when running against a Godot 4.4.x Android library.

Fixes https://github.com/GodotVR/godot_openxr_vendors/issues/402