### PR TITLE
Only add shader globals when the environment depth extensions are enabled

### DIFF
--- a/plugin/src/main/cpp/extensions/openxr_android_environment_depth_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_environment_depth_extension_wrapper.cpp
@@ -602,16 +602,38 @@ static void create_shader_global_uniform(const String &p_name, RenderingServer::
 	}
 }
 
-void OpenXRAndroidEnvironmentDepthExtensionWrapper::setup_global_uniforms() {
-	if (already_setup_global_uniforms) {
-		return;
+static void remove_shader_global_uniform(const String &p_name, RenderingServer *p_rendering_server, ProjectSettings *p_project_settings) {
+	String setting_name = "shader_globals/" + p_name;
+	if (p_project_settings->has_setting(setting_name)) {
+		p_rendering_server->global_shader_parameter_remove(p_name);
+		p_project_settings->clear(setting_name);
 	}
+}
 
+void OpenXRAndroidEnvironmentDepthExtensionWrapper::setup_global_uniforms() {
 	RenderingServer *rs = RenderingServer::get_singleton();
 	ERR_FAIL_NULL(rs);
 
 	ProjectSettings *project_settings = ProjectSettings::get_singleton();
 	ERR_FAIL_NULL(project_settings);
+
+	bool enabled = project_settings->get_setting_with_override("xr/openxr/extensions/androidxr/environment_depth");
+	if (!enabled) {
+		remove_shader_global_uniform(ANDROID_ENVIRONMENT_DEPTH_AVAILABLE_NAME, rs, project_settings);
+		remove_shader_global_uniform(ANDROID_ENVIRONMENT_DEPTH_TEXTURE_NAME, rs, project_settings);
+		remove_shader_global_uniform(ANDROID_ENVIRONMENT_DEPTH_RESOLUTION_NAME, rs, project_settings);
+		remove_shader_global_uniform(ANDROID_ENVIRONMENT_DEPTH_TANFOV_LEFT_NAME, rs, project_settings);
+		remove_shader_global_uniform(ANDROID_ENVIRONMENT_DEPTH_TANFOV_RIGHT_NAME, rs, project_settings);
+		remove_shader_global_uniform(ANDROID_ENVIRONMENT_DEPTH_CAMERA_TO_WORLD_LEFT_NAME, rs, project_settings);
+		remove_shader_global_uniform(ANDROID_ENVIRONMENT_DEPTH_CAMERA_TO_WORLD_RIGHT_NAME, rs, project_settings);
+
+		already_setup_global_uniforms = false;
+		return;
+	}
+
+	if (already_setup_global_uniforms) {
+		return;
+	}
 
 	Engine *engine = Engine::get_singleton();
 	ERR_FAIL_NULL(engine);

--- a/plugin/src/main/cpp/extensions/openxr_meta_environment_depth_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_meta_environment_depth_extension_wrapper.cpp
@@ -562,22 +562,24 @@ void OpenXRMetaEnvironmentDepthExtensionWrapper::setup_global_uniforms() {
 
 	bool enabled = project_settings->get_setting_with_override("xr/openxr/extensions/meta/environment_depth");
 
-	if (already_setup_global_uniforms) {
-		if (!enabled) {
-			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_AVAILABLE_NAME, rs, project_settings);
-			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_TEXTURE_NAME, rs, project_settings);
-			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_TEXEL_SIZE_NAME, rs, project_settings);
-			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_PROJECTION_VIEW_LEFT_NAME, rs, project_settings);
-			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_PROJECTION_VIEW_RIGHT_NAME, rs, project_settings);
-			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_INV_PROJECTION_VIEW_LEFT_NAME, rs, project_settings);
-			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_INV_PROJECTION_VIEW_RIGHT_NAME, rs, project_settings);
-			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_FROM_CAMERA_PROJECTION_LEFT_NAME, rs, project_settings);
-			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_FROM_CAMERA_PROJECTION_RIGHT_NAME, rs, project_settings);
-			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_TO_CAMERA_PROJECTION_LEFT_NAME, rs, project_settings);
-			remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_TO_CAMERA_PROJECTION_RIGHT_NAME, rs, project_settings);
+	if (!enabled) {
+		remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_AVAILABLE_NAME, rs, project_settings);
+		remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_TEXTURE_NAME, rs, project_settings);
+		remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_TEXEL_SIZE_NAME, rs, project_settings);
+		remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_PROJECTION_VIEW_LEFT_NAME, rs, project_settings);
+		remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_PROJECTION_VIEW_RIGHT_NAME, rs, project_settings);
+		remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_INV_PROJECTION_VIEW_LEFT_NAME, rs, project_settings);
+		remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_INV_PROJECTION_VIEW_RIGHT_NAME, rs, project_settings);
+		remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_FROM_CAMERA_PROJECTION_LEFT_NAME, rs, project_settings);
+		remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_FROM_CAMERA_PROJECTION_RIGHT_NAME, rs, project_settings);
+		remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_TO_CAMERA_PROJECTION_LEFT_NAME, rs, project_settings);
+		remove_shader_global_uniform(META_ENVIRONMENT_DEPTH_TO_CAMERA_PROJECTION_RIGHT_NAME, rs, project_settings);
 
-			already_setup_global_uniforms = false;
-		}
+		already_setup_global_uniforms = false;
+		return;
+	}
+
+	if (already_setup_global_uniforms) {
 		return;
 	}
 


### PR DESCRIPTION
It looks like I didn't get https://github.com/GodotVR/godot_openxr_vendors/pull/377 quite right, and the Meta depth extension wrapper can still add the global uniforms

This PR fixes the Meta extension wrapper, and then applies the same logic to the Android one as well