### PR TITLE
Replace remaining header guards with `#pragma once`

### DIFF
--- a/plugin/src/main/cpp/include/classes/openxr_fb_hand_tracking_mesh.h
+++ b/plugin/src/main/cpp/include/classes/openxr_fb_hand_tracking_mesh.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_HAND_TRACKING_MESH_H
-#define OPENXR_FB_HAND_TRACKING_MESH_H
+#pragma once
 
 #include <godot_cpp/classes/material.hpp>
 #include <godot_cpp/classes/mesh_instance3d.hpp>
@@ -80,5 +79,3 @@ public:
 } //namespace godot
 
 VARIANT_ENUM_CAST(OpenXRFbHandTrackingMesh::Hand);
-
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_fb_passthrough_geometry.h
+++ b/plugin/src/main/cpp/include/classes/openxr_fb_passthrough_geometry.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_PASSTHROUGH_GEOMETRY_H
-#define OPENXR_FB_PASSTHROUGH_GEOMETRY_H
+#pragma once
 
 #include <godot_cpp/classes/mesh.hpp>
 #include <godot_cpp/classes/mesh_instance3d.hpp>
@@ -66,5 +65,3 @@ public:
 	bool get_enable_hole_punch() const;
 };
 } //namespace godot
-
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_fb_render_model.h
+++ b/plugin/src/main/cpp/include/classes/openxr_fb_render_model.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_RENDER_MODEL_H
-#define OPENXR_FB_RENDER_MODEL_H
+#pragma once
 
 #include <godot_cpp/classes/node3d.hpp>
 
@@ -65,5 +64,3 @@ public:
 } //namespace godot
 
 VARIANT_ENUM_CAST(OpenXRFbRenderModel::Model);
-
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_fb_scene_manager.h
+++ b/plugin/src/main/cpp/include/classes/openxr_fb_scene_manager.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_SCENE_MANAGER_H
-#define OPENXR_FB_SCENE_MANAGER_H
+#pragma once
 
 #include <openxr/openxr.h>
 
@@ -116,5 +115,3 @@ public:
 	Ref<OpenXRFbSpatialEntity> get_spatial_entity(const StringName &p_uuids) const;
 };
 } // namespace godot
-
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_fb_spatial_anchor_manager.h
+++ b/plugin/src/main/cpp/include/classes/openxr_fb_spatial_anchor_manager.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_SPATIAL_ANCHOR_MANAGER_H
-#define OPENXR_FB_SPATIAL_ANCHOR_MANAGER_H
+#pragma once
 
 #include <openxr/openxr.h>
 
@@ -111,5 +110,3 @@ public:
 	Ref<OpenXRFbSpatialEntity> get_spatial_entity(const StringName &p_uuids) const;
 };
 } // namespace godot
-
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_fb_spatial_entity.h
+++ b/plugin/src/main/cpp/include/classes/openxr_fb_spatial_entity.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_SPATIAL_ENTITY_H
-#define OPENXR_FB_SPATIAL_ENTITY_H
+#pragma once
 
 #include <openxr/openxr.h>
 
@@ -125,5 +124,3 @@ public:
 
 VARIANT_ENUM_CAST(OpenXRFbSpatialEntity::StorageLocation);
 VARIANT_ENUM_CAST(OpenXRFbSpatialEntity::ComponentType);
-
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_fb_spatial_entity_batch.h
+++ b/plugin/src/main/cpp/include/classes/openxr_fb_spatial_entity_batch.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_SPATIAL_ENTITY_BATCH_H
-#define OPENXR_FB_SPATIAL_ENTITY_BATCH_H
+#pragma once
 
 #include <openxr/openxr.h>
 
@@ -63,5 +62,3 @@ public:
 	OpenXRFbSpatialEntityBatch(const TypedArray<OpenXRFbSpatialEntity> &p_entities);
 };
 } // namespace godot
-
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_fb_spatial_entity_query.h
+++ b/plugin/src/main/cpp/include/classes/openxr_fb_spatial_entity_query.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_SPATIAL_ENTITY_QUERY_H
-#define OPENXR_FB_SPATIAL_ENTITY_QUERY_H
+#pragma once
 
 #include <openxr/openxr.h>
 #include <godot_cpp/classes/ref_counted.hpp>
@@ -88,5 +87,3 @@ public:
 } // namespace godot
 
 VARIANT_ENUM_CAST(OpenXRFbSpatialEntityQuery::QueryType);
-
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_fb_spatial_entity_user.h
+++ b/plugin/src/main/cpp/include/classes/openxr_fb_spatial_entity_user.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_SPATIAL_ENTITY_USER_H
-#define OPENXR_FB_SPATIAL_ENTITY_USER_H
+#pragma once
 
 #include <openxr/openxr.h>
 
@@ -57,5 +56,3 @@ public:
 	OpenXRFbSpatialEntityUser(uint64_t p_user_id);
 };
 } // namespace godot
-
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_meta_passthrough_color_lut.h
+++ b/plugin/src/main/cpp/include/classes/openxr_meta_passthrough_color_lut.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_PASSTHROUGH_COLOR_LUT_H
-#define OPENXR_FB_PASSTHROUGH_COLOR_LUT_H
+#pragma once
 
 #include <godot_cpp/classes/image.hpp>
 #include <godot_cpp/classes/ref_counted.hpp>
@@ -68,5 +67,3 @@ public:
 } // namespace godot
 
 VARIANT_ENUM_CAST(OpenXRMetaPassthroughColorLut::ColorLutChannels);
-
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector.h
+++ b/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_ML_MARKER_DETECTOR_H
-#define OPENXR_ML_MARKER_DETECTOR_H
+#pragma once
 
 #include <openxr/openxr.h>
 #include <godot_cpp/classes/node.hpp>
@@ -83,5 +82,3 @@ public:
 } // namespace godot
 
 VARIANT_ENUM_CAST(OpenXRMlMarkerDetector::Status);
-
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector_april_tag_settings.h
+++ b/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector_april_tag_settings.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_ML_MARKER_DETECTOR_APRIL_TAG_SETTINGS_H
-#define OPENXR_ML_MARKER_DETECTOR_APRIL_TAG_SETTINGS_H
+#pragma once
 
 #include "classes/openxr_ml_marker_detector_settings.h"
 
@@ -69,5 +68,3 @@ public:
 } // namespace godot
 
 VARIANT_ENUM_CAST(OpenXRMlMarkerDetectorAprilTagSettings::AprilTagDictionary);
-
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector_aruco_settings.h
+++ b/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector_aruco_settings.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_ML_MARKER_DETECTOR_ARUCO_SETTINGS_H
-#define OPENXR_ML_MARKER_DETECTOR_ARUCO_SETTINGS_H
+#pragma once
 
 #include "classes/openxr_ml_marker_detector_settings.h"
 
@@ -81,5 +80,3 @@ public:
 } // namespace godot
 
 VARIANT_ENUM_CAST(OpenXRMlMarkerDetectorArucoSettings::ArucoDictionary);
-
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector_code_128_settings.h
+++ b/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector_code_128_settings.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_ML_MARKER_DETECTOR_CODE_128_SETTINGS_H
-#define OPENXR_ML_MARKER_DETECTOR_CODE_128_SETTINGS_H
+#pragma once
 
 #include "classes/openxr_ml_marker_detector_settings.h"
 
@@ -45,4 +44,3 @@ public:
 	OpenXRMlMarkerDetectorCode128Settings();
 };
 } // namespace godot
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector_ean_13_settings.h
+++ b/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector_ean_13_settings.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_ML_MARKER_DETECTOR_EAN_13_SETTINGS_H
-#define OPENXR_ML_MARKER_DETECTOR_EAN_13_SETTINGS_H
+#pragma once
 
 #include "classes/openxr_ml_marker_detector_settings.h"
 
@@ -45,4 +44,3 @@ public:
 	OpenXRMlMarkerDetectorEan13Settings();
 };
 } // namespace godot
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector_profile_settings.h
+++ b/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector_profile_settings.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_ML_MARKER_DETECTOR_PROFILE_SETTINGS_H
-#define OPENXR_ML_MARKER_DETECTOR_PROFILE_SETTINGS_H
+#pragma once
 
 #include <godot_cpp/classes/resource.hpp>
 #include <godot_cpp/core/binder_common.hpp>
@@ -103,5 +102,3 @@ VARIANT_ENUM_CAST(OpenXRMlMarkerDetectorProfileSettings::Resolution);
 VARIANT_ENUM_CAST(OpenXRMlMarkerDetectorProfileSettings::Camera);
 VARIANT_ENUM_CAST(OpenXRMlMarkerDetectorProfileSettings::CornerRefineMethod);
 VARIANT_ENUM_CAST(OpenXRMlMarkerDetectorProfileSettings::FullAnalysisInterval);
-
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector_qr_settings.h
+++ b/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector_qr_settings.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_ML_MARKER_DETECTOR_QR_SETTINGS_H
-#define OPENXR_ML_MARKER_DETECTOR_QR_SETTINGS_H
+#pragma once
 
 #include "classes/openxr_ml_marker_detector_settings.h"
 
@@ -55,5 +54,3 @@ public:
 	OpenXRMlMarkerDetectorQrSettings();
 };
 } // namespace godot
-
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector_settings.h
+++ b/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector_settings.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_ML_MARKER_DETECTOR_SETTINGS_H
-#define OPENXR_ML_MARKER_DETECTOR_SETTINGS_H
+#pragma once
 
 #include "classes/openxr_ml_marker_detector_profile_settings.h"
 #include <godot_cpp/classes/resource.hpp>
@@ -81,5 +80,3 @@ public:
 
 VARIANT_ENUM_CAST(OpenXRMlMarkerDetectorSettings::MarkerType);
 VARIANT_ENUM_CAST(OpenXRMlMarkerDetectorSettings::MarkerDetectorProfile);
-
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector_upc_a_settings.h
+++ b/plugin/src/main/cpp/include/classes/openxr_ml_marker_detector_upc_a_settings.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_ML_MARKER_DETECTOR_UPC_A_SETTINGS_H
-#define OPENXR_ML_MARKER_DETECTOR_UPC_A_SETTINGS_H
+#pragma once
 
 #include "classes/openxr_ml_marker_detector_settings.h"
 
@@ -45,4 +44,3 @@ public:
 	OpenXRMlMarkerDetectorUpcASettings();
 };
 } // namespace godot
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_ml_marker_tracker.h
+++ b/plugin/src/main/cpp/include/classes/openxr_ml_marker_tracker.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_ML_MARKER_TRACKER_H
-#define OPENXR_ML_MARKER_TRACKER_H
+#pragma once
 
 #include "classes/openxr_ml_marker_detector_settings.h"
 #include <openxr/openxr.h>
@@ -78,4 +77,3 @@ public:
 	OpenXRMlMarkerTracker(XrMarkerDetectorML p_marker_detector, XrMarkerML p_marker_atom, OpenXRMlMarkerDetectorSettings::MarkerType p_marker_type);
 };
 } // namespace godot
-#endif

--- a/plugin/src/main/cpp/include/classes/openxr_ml_marker_understanding_manager.h
+++ b/plugin/src/main/cpp/include/classes/openxr_ml_marker_understanding_manager.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_ML_MARKER_UNDERSTANDING_MANAGER_H
-#define OPENXR_ML_MARKER_UNDERSTANDING_MANAGER_H
+#pragma once
 
 #include <openxr/openxr.h>
 #include <godot_cpp/classes/node.hpp>
@@ -89,5 +88,3 @@ public:
 	void hide();
 };
 } // namespace godot
-
-#endif

--- a/plugin/src/main/cpp/include/extensions/openxr_android_face_tracking_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_android_face_tracking_extension_wrapper.h
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_ANDROID_FACETRACKING_EXTENSION_WRAPPER_H
-#define OPENXR_ANDROID_FACETRACKING_EXTENSION_WRAPPER_H
+#pragma once
 
 #include <androidxr/androidxr.h>
 
@@ -114,5 +113,3 @@ private:
 };
 
 VARIANT_ENUM_CAST(OpenXRAndroidFaceTrackingExtensionWrapper::CalibrationState);
-
-#endif // OPENXR_ANDROID_FACETRACKING_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/include/extensions/openxr_android_passthrough_camera_state_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_android_passthrough_camera_state_extension_wrapper.h
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef AndroidXR_PASSTHROUGH_CAMERA_STATE_EXTENSION_H
-#define AndroidXR_PASSTHROUGH_CAMERA_STATE_EXTENSION_H
+#pragma once
 
 #include <androidxr/androidxr.h>
 #include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
@@ -75,5 +74,3 @@ private:
 };
 
 VARIANT_ENUM_CAST(OpenXRAndroidPassthroughCameraStateExtensionWrapper::PassthroughCameraState);
-
-#endif // AndroidXR_PASSTHROUGH_CAMERA_STATE_EXTENSION_H

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_body_tracking_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_body_tracking_extension_wrapper.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_BODY_TRACKING_EXTENSION_WRAPPER_H
-#define OPENXR_FB_BODY_TRACKING_EXTENSION_WRAPPER_H
+#pragma once
 
 // @todo GH Issue 304: Remove check for meta headers when feature becomes part of OpenXR spec.
 #ifdef META_HEADERS_ENABLED
@@ -210,5 +209,3 @@ private:
 VARIANT_ENUM_CAST(OpenXRFbBodyTrackingExtensionWrapper::BodyTrackingFidelity);
 VARIANT_ENUM_CAST(OpenXRFbBodyTrackingExtensionWrapper::BodyTrackingCalibrationState);
 #endif
-
-#endif // OPENXR_FB_BODY_TRACKING_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_composition_layer_alpha_blend_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_composition_layer_alpha_blend_extension_wrapper.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_COMPOSITION_LAYER_ALPHA_BLEND_EXTENSION_WRAPPER_H
-#define OPENXR_FB_COMPOSITION_LAYER_ALPHA_BLEND_EXTENSION_WRAPPER_H
+#pragma once
 
 #include <openxr/openxr.h>
 
@@ -81,5 +80,3 @@ private:
 };
 
 VARIANT_ENUM_CAST(OpenXRFbCompositionLayerAlphaBlendExtensionWrapper::BlendFactor);
-
-#endif // OPENXR_FB_COMPOSITION_LAYER_ALPHA_BLEND_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_composition_layer_image_layout_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_composition_layer_image_layout_extension_wrapper.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_COMPOSITION_LAYER_IMAGE_LAYOUT_EXTENSION_WRAPPER_H
-#define OPENXR_FB_COMPOSITION_LAYER_IMAGE_LAYOUT_EXTENSION_WRAPPER_H
+#pragma once
 
 #include <openxr/openxr.h>
 
@@ -70,5 +69,3 @@ private:
 
 	HashMap<const XrCompositionLayerBaseHeader *, XrCompositionLayerImageLayoutFB> layer_structs;
 };
-
-#endif // OPENXR_FB_COMPOSITION_LAYER_IMAGE_LAYOUT_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_composition_layer_secure_content_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_composition_layer_secure_content_extension_wrapper.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_COMPOSITION_LAYER_SECURE_CONTENT_EXTENSION_WRAPPER_H
-#define OPENXR_FB_COMPOSITION_LAYER_SECURE_CONTENT_EXTENSION_WRAPPER_H
+#pragma once
 
 #include <openxr/openxr.h>
 
@@ -76,5 +75,3 @@ private:
 
 	HashMap<const XrCompositionLayerBaseHeader *, XrCompositionLayerSecureContentFB> layer_structs;
 };
-
-#endif // OPENXR_FB_COMPOSITION_LAYER_SECURE_CONTENT_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_composition_layer_settings_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_composition_layer_settings_extension_wrapper.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_COMPOSITION_LAYER_SETTINGS_EXTENSION_WRAPPER_H
-#define OPENXR_FB_COMPOSITION_LAYER_SETTINGS_EXTENSION_WRAPPER_H
+#pragma once
 
 #include <openxr/openxr.h>
 
@@ -84,5 +83,3 @@ private:
 
 VARIANT_ENUM_CAST(OpenXRFbCompositionLayerSettingsExtensionWrapper::SupersamplingMode);
 VARIANT_ENUM_CAST(OpenXRFbCompositionLayerSettingsExtensionWrapper::SharpeningMode);
-
-#endif // OPENXR_FB_COMPOSITION_LAYER_SETTINGS_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_face_tracking_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_face_tracking_extension_wrapper.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_FACE_TRACKING_EXTENSION_WRAPPER_H
-#define OPENXR_FB_FACE_TRACKING_EXTENSION_WRAPPER_H
+#pragma once
 
 #include <openxr/openxr.h>
 #include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
@@ -103,5 +102,3 @@ private:
 	// Godot XRFaceTracker instance.
 	Ref<XRFaceTracker> xr_face_tracker;
 };
-
-#endif // OPENXR_FB_FACE_TRACKING_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_hand_tracking_aim_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_hand_tracking_aim_extension_wrapper.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_HAND_TRACKING_AIM_EXTENSION_WRAPPER_H
-#define OPENXR_FB_HAND_TRACKING_AIM_EXTENSION_WRAPPER_H
+#pragma once
 
 #include <openxr/openxr.h>
 #include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
@@ -86,5 +85,3 @@ private:
 
 	XrHandTrackingAimStateFB aim_state[Hand::HAND_MAX];
 };
-
-#endif // OPENXR_FB_HAND_TRACKING_AIM_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_hand_tracking_capsules_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_hand_tracking_capsules_extension_wrapper.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_HAND_TRACKING_CAPSULES_EXTENSION_WRAPPER_H
-#define OPENXR_FB_HAND_TRACKING_CAPSULES_EXTENSION_WRAPPER_H
+#pragma once
 
 #include <openxr/openxr.h>
 #include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
@@ -80,5 +79,3 @@ private:
 	static const int HAND_MAX = 2;
 	XrHandTrackingCapsulesStateFB capsules_state[HAND_MAX];
 };
-
-#endif // OPENXR_FB_HAND_TRACKING_CAPSULES_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_HAND_TRACKING_MESH_EXTENSION_WRAPPER_H
-#define OPENXR_FB_HAND_TRACKING_MESH_EXTENSION_WRAPPER_H
+#pragma once
 
 #include "classes/openxr_fb_hand_tracking_mesh.h"
 
@@ -113,5 +112,3 @@ private:
 
 	bool fetch_hand_mesh_data(Hand p_hand);
 };
-
-#endif // OPENXR_FB_HAND_TRACKING_MESH_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_passthrough_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_passthrough_extension_wrapper.h
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_PASSTHROUGH_EXTENSION_WRAPPER_H
-#define OPENXR_FB_PASSTHROUGH_EXTENSION_WRAPPER_H
+#pragma once
 
 #include "classes/openxr_fb_passthrough_geometry.h"
 #include "classes/openxr_meta_passthrough_color_lut.h"
@@ -434,5 +433,3 @@ private:
 VARIANT_ENUM_CAST(OpenXRFbPassthroughExtensionWrapper::LayerPurpose);
 VARIANT_ENUM_CAST(OpenXRFbPassthroughExtensionWrapper::PassthroughFilter);
 VARIANT_ENUM_CAST(OpenXRFbPassthroughExtensionWrapper::PassthroughStateChangedEvent);
-
-#endif // OPENXR_FB_PASSTHROUGH_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_render_model_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_render_model_extension_wrapper.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_RENDER_MODEL_EXTENSION_WRAPPER_H
-#define OPENXR_FB_RENDER_MODEL_EXTENSION_WRAPPER_H
+#pragma once
 
 #include <openxr/openxr.h>
 #include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
@@ -108,5 +107,3 @@ private:
 	bool openxr_session_active = false;
 	XrSystemRenderModelPropertiesFB system_render_model_properties;
 };
-
-#endif // OPENXR_FB_RENDER_MODEL_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_scene_capture_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_scene_capture_extension_wrapper.h
@@ -30,8 +30,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_SCENE_CAPTURE_EXTENSION_WRAPPER_H
-#define OPENXR_FB_SCENE_CAPTURE_EXTENSION_WRAPPER_H
+#pragma once
 
 #include <openxr/openxr.h>
 #include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
@@ -110,5 +109,3 @@ private:
 
 	bool scene_capture_enabled = false;
 };
-
-#endif // OPENXR_FB_SCENE_CAPTURE_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_space_warp_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_space_warp_extension_wrapper.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_SPACE_WARP_EXTENSION_WRAPPER_H
-#define OPENXR_FB_SPACE_WARP_EXTENSION_WRAPPER_H
+#pragma once
 
 #include <openxr/openxr.h>
 #include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
@@ -98,5 +97,3 @@ private:
 		Transform3D previous_transform = { { 1.0, 0.0, 0.0 }, { 0.0, 1.0, 0.0 }, { 0.0, 0.0, 1.0 }, { 0.0, 0.0, 0.0 } };
 	} render_state;
 };
-
-#endif // OPENXR_FB_SPACE_WARP_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_spatial_entity_storage_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_spatial_entity_storage_extension_wrapper.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_FB_SPATIAL_ENTITY_STORAGE_EXTENSION_WRAPPER_H
-#define OPENXR_FB_SPATIAL_ENTITY_STORAGE_EXTENSION_WRAPPER_H
+#pragma once
 
 #include <openxr/openxr.h>
 #include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
@@ -102,5 +101,3 @@ private:
 
 	bool fb_spatial_entity_storage_ext = false;
 };
-
-#endif

--- a/plugin/src/main/cpp/include/extensions/openxr_htc_facial_tracking_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_htc_facial_tracking_extension_wrapper.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_HTC_FACIAL_TRACKING_EXTENSION_WRAPPER_H
-#define OPENXR_HTC_FACIAL_TRACKING_EXTENSION_WRAPPER_H
+#pragma once
 
 #include <openxr/openxr.h>
 #include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
@@ -105,5 +104,3 @@ private:
 	// Godot XRFaceTracker instance.
 	Ref<XRFaceTracker> xr_face_tracker;
 };
-
-#endif // OPENXR_HTC_FACIAL_TRACKING_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/include/extensions/openxr_htc_passthrough_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_htc_passthrough_extension_wrapper.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_HTC_PASSTHROUGH_EXTENSION_WRAPPER_H
-#define OPENXR_HTC_PASSTHROUGH_EXTENSION_WRAPPER_H
+#pragma once
 
 #include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
 #include <godot_cpp/classes/xr_interface.hpp>
@@ -118,5 +117,3 @@ private:
 		return XRInterface::XR_ENV_BLEND_MODE_OPAQUE;
 	}
 };
-
-#endif // OPENXR_HTC_PASSTHROUGH_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/include/extensions/openxr_meta_boundary_visibility_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_meta_boundary_visibility_extension_wrapper.h
@@ -27,10 +27,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#pragma once
+
 // @todo GH Issue 304: Remove check for meta headers when feature becomes part of OpenXR spec.
 #ifdef META_HEADERS_ENABLED
-#ifndef OPENXR_META_BOUNDARY_VISIBILITY_EXTENSION_WRAPPER_H
-#define OPENXR_META_BOUNDARY_VISIBILITY_EXTENSION_WRAPPER_H
 
 #include <meta_openxr_preview/meta_boundary_visibility.h>
 #include <openxr/openxr.h>
@@ -88,5 +88,4 @@ private:
 	XrBoundaryVisibilityMETA current_boundary_visibility = XR_BOUNDARY_VISIBILITY_NOT_SUPPRESSED_META;
 };
 
-#endif // OPENXR_META_BOUNDARY_VISIBILITY_EXTENSION_WRAPPER_H
 #endif // META_HEADERS_ENABLED

--- a/plugin/src/main/cpp/include/extensions/openxr_meta_recommended_layer_resolution_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_meta_recommended_layer_resolution_extension_wrapper.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_META_RECOMMENDED_LAYER_RESOLUTION_EXTENSION_WRAPPER_H
-#define OPENXR_META_RECOMMENDED_LAYER_RESOLUTION_EXTENSION_WRAPPER_H
+#pragma once
 
 #include <openxr/openxr.h>
 #include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
@@ -85,5 +84,3 @@ private:
 		false, // isValid
 	};
 };
-
-#endif // OPENXR_META_RECOMMENDED_LAYER_RESOLUTION_EXTENSION_WRAPPER_H

--- a/plugin/src/main/cpp/include/extensions/openxr_ml_marker_understanding_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_ml_marker_understanding_extension_wrapper.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_ML_MARKER_UNDERSTANDING_EXTENSION_WRAPPER_H
-#define OPENXR_ML_MARKER_UNDERSTANDING_EXTENSION_WRAPPER_H
+#pragma once
 
 #include <openxr/openxr.h>
 #include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
@@ -154,5 +153,3 @@ private:
 	std::map<godot::String, bool *> request_extensions;
 	bool ml_marker_understanding_ext = false;
 };
-
-#endif

--- a/plugin/src/main/cpp/include/util.h
+++ b/plugin/src/main/cpp/include/util.h
@@ -27,8 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef UTIL_H
-#define UTIL_H
+#pragma once
 
 #include <godot_cpp/variant/string_name.hpp>
 
@@ -129,5 +128,3 @@ namespace OpenXRUtilities {
 godot::StringName uuid_to_string_name(const XrUuid &p_uuid);
 void xrMatrix4x4f_to_godot_projection(XrMatrix4x4f *m, godot::Projection &p);
 }; //namespace OpenXRUtilities
-
-#endif // UTIL_H


### PR DESCRIPTION
Some time ago, Godot switched from header guards to using `#pragma once`, and we decided follow along and try and to use `#pragma once` going forward.

(However, it looks like we didn't totally stick with that - there's some newer files that were added with header guards - I think because folks copy-paste old files to start their new files.)

This PR goes through all the headers that aren't third-party, and switches to `#pragma once`