### PR TITLE
Fix Android XR manifest entries for face tracking

### DIFF
--- a/plugin/src/main/cpp/export/android_xr_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/android_xr_export_plugin.cpp
@@ -45,15 +45,6 @@ AndroidXREditorExportPlugin::AndroidXREditorExportPlugin() {
 			PROPERTY_USAGE_DEFAULT,
 			EYE_TRACKING_OPTIONAL_VALUE,
 			false);
-	_face_tracking_option = _generate_export_option(
-			"android_xr_features/face_tracking",
-			"",
-			Variant::Type::INT,
-			PROPERTY_HINT_ENUM,
-			"Optional,Required",
-			PROPERTY_USAGE_DEFAULT,
-			FACE_TRACKING_OPTIONAL_VALUE,
-			false);
 	_hand_tracking_option = _generate_export_option(
 			"android_xr_features/hand_tracking",
 			"",
@@ -95,7 +86,6 @@ TypedArray<Dictionary> AndroidXREditorExportPlugin::_get_export_options(const Re
 
 	export_options.append(_get_vendor_toggle_option());
 	export_options.append(_eye_tracking_option);
-	export_options.append(_face_tracking_option);
 	export_options.append(_hand_tracking_option);
 	export_options.append(_tracked_controllers_option);
 	export_options.append(_recommended_boundary_type_option);
@@ -128,10 +118,6 @@ String AndroidXREditorExportPlugin::_get_export_option_warning(const Ref<EditorE
 	if (option == "android_xr_features/eye_tracking") {
 		if (!openxr_enabled && (bool)project_settings->get_setting_with_override("xr/openxr/extensions/eye_gaze_interaction")) {
 			return "\"Eye Tracking\" requires \"XR Mode\" to be \"OpenXR\".\n";
-		}
-	} else if (option == "android_xr_features/face_tracking") {
-		if (!openxr_enabled && _get_int_option(option, FACE_TRACKING_OPTIONAL_VALUE) != FACE_TRACKING_OPTIONAL_VALUE) {
-			return "\"Face Tracking\" requires \"XR Mode\" to be \"OpenXR\".\n";
 		}
 	} else if (option == "android_xr_features/hand_tracking") {
 		if (!openxr_enabled && (bool)project_settings->get_setting_with_override("xr/openxr/extensions/hand_tracking")) {
@@ -296,7 +282,7 @@ String AndroidXREditorExportPlugin::_get_android_manifest_element_contents(const
 	}
 
 	// Check for face tracking
-	if (FACE_TRACKING_REQUIRED_VALUE == _get_int_option("android_xr_features/face_tracking", FACE_TRACKING_OPTIONAL_VALUE)) {
+	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/androidxr/face_tracking")) {
 		contents += "    <uses-permission android:name=\"android.permission.FACE_TRACKING\" />\n";
 	}
 

--- a/plugin/src/main/cpp/include/export/android_xr_export_plugin.h
+++ b/plugin/src/main/cpp/include/export/android_xr_export_plugin.h
@@ -41,9 +41,6 @@ class AndroidXREditorExportPlugin : public OpenXRVendorsEditorExportPlugin {
 	static const int EYE_TRACKING_OPTIONAL_VALUE = 0;
 	static const int EYE_TRACKING_REQUIRED_VALUE = 1;
 
-	static const int FACE_TRACKING_OPTIONAL_VALUE = 0;
-	static const int FACE_TRACKING_REQUIRED_VALUE = 1;
-
 	static const int HAND_TRACKING_OPTIONAL_VALUE = 0;
 	static const int HAND_TRACKING_REQUIRED_VALUE = 1;
 
@@ -73,7 +70,6 @@ protected:
 	static void _bind_methods();
 
 	Dictionary _eye_tracking_option;
-	Dictionary _face_tracking_option;
 	Dictionary _hand_tracking_option;
 	Dictionary _tracked_controllers_option;
 	Dictionary _recommended_boundary_type_option;

--- a/samples/androidxr-depth-texture-sample/export_presets.cfg
+++ b/samples/androidxr-depth-texture-sample/export_presets.cfg
@@ -244,7 +244,6 @@ pico_xr_features/face_tracking=0
 pico_xr_features/hand_tracking=1
 xr_features/enable_androidxr_plugin=true
 android_xr_features/eye_tracking=0
-android_xr_features/face_tracking=0
 android_xr_features/hand_tracking=0
 android_xr_features/tracked_controllers=0
 android_xr_features/recommended_boundary_type=0

--- a/samples/meta-body-tracking-sample/export_presets.cfg
+++ b/samples/meta-body-tracking-sample/export_presets.cfg
@@ -466,7 +466,6 @@ permissions/write_social_stream=false
 permissions/write_sync_settings=false
 permissions/write_user_dictionary=false
 android_xr_features/eye_tracking=0
-android_xr_features/face_tracking=1
 android_xr_features/hand_tracking=0
 android_xr_features/recommended_boundary_type=0
 android_xr_features/tracked_controllers=1

--- a/samples/performance-metrics-sample/export_presets.cfg
+++ b/samples/performance-metrics-sample/export_presets.cfg
@@ -248,7 +248,6 @@ android_xr_features/eye_tracking=0
 android_xr_features/hand_tracking=0
 android_xr_features/tracked_controllers=0
 android_xr_features/recommended_boundary_type=0
-android_xr_features/face_tracking=0
 
 [preset.1]
 


### PR DESCRIPTION
Face tracking permission was incorrectly setup to depend on face tracking feature flag when generating manifest.

This PR fixes this issue and removes the face tracking feature flag as it is not necessary.