### PR TITLE
Implement XR_EXTX2_stationary_reference_space extension

### DIFF
--- a/doc_classes/OpenXRStationaryReferenceSpaceExtension.xml
+++ b/doc_classes/OpenXRStationaryReferenceSpaceExtension.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRStationaryReferenceSpaceExtension" inherits="OpenXRExtensionWrapper" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Wraps the [code]XR_EXTX2_stationary_reference_space[/code] extension.
+	</brief_description>
+	<description>
+		Wraps the [code]XR_EXTX2_stationary_reference_space[/code] extension.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_stationary_reference_space_uuid">
+			<return type="StringName" />
+			<description>
+				Returns a [code]StringName[/code] UUID referencing the active stationary reference space.
+			</description>
+		</method>
+		<method name="is_stationary_reference_space_available">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if stationary reference space is available for use.
+			</description>
+		</method>
+		<method name="set_stationary_reference_space_enabled">
+			<return type="void" />
+			<param index="0" name="enable" type="bool" />
+			<description>
+				Sets the stationary reference space as enabled or disabled.
+				Note: The Stationary Reference Space project setting must be enabled in order to enable the reference space.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/plugin/src/main/cpp/export/meta_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/meta_export_plugin.cpp
@@ -434,6 +434,11 @@ String MetaEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/boundary_visibility")) {
 		contents += "    <uses-permission android:name=\"com.oculus.permission.BOUNDARY_VISIBILITY\" />\n";
 	}
+
+	// Check for stationary reference space
+	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/stationary_reference_space")) {
+		contents += "    <uses-feature android:name=\"com.oculus.experimental.enabled\" />\n";
+	}
 #endif // META_HEADERS_ENABLED
 
 	// Check for overlay keyboard

--- a/plugin/src/main/cpp/extensions/openxr_stationary_reference_space_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_stationary_reference_space_extension.cpp
@@ -1,0 +1,176 @@
+/**************************************************************************/
+/*  openxr_stationary_reference_space_extension.cpp                       */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+// @todo GH Issue 304: Remove check for meta headers when feature becomes part of OpenXR spec.
+#ifdef META_HEADERS_ENABLED
+#include "extensions/openxr_stationary_reference_space_extension.h"
+
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/xr_interface.hpp>
+#include <godot_cpp/classes/xr_server.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+OpenXRStationaryReferenceSpaceExtension *OpenXRStationaryReferenceSpaceExtension::singleton = nullptr;
+
+OpenXRStationaryReferenceSpaceExtension *OpenXRStationaryReferenceSpaceExtension::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRStationaryReferenceSpaceExtension());
+	}
+	return singleton;
+}
+
+OpenXRStationaryReferenceSpaceExtension::OpenXRStationaryReferenceSpaceExtension() :
+		OpenXRExtensionWrapper() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRStationaryReferenceSpaceExtension singleton already exists.");
+
+	request_extensions[XR_EXTX2_STATIONARY_REFERENCE_SPACE_EXTENSION_NAME] = &stationary_reference_space_ext;
+	singleton = this;
+}
+
+OpenXRStationaryReferenceSpaceExtension::~OpenXRStationaryReferenceSpaceExtension() {
+	cleanup();
+	singleton = nullptr;
+}
+
+godot::Dictionary OpenXRStationaryReferenceSpaceExtension::_get_requested_extensions(uint64_t p_xr_version) {
+	godot::Dictionary result;
+	for (auto ext : request_extensions) {
+		godot::String key = ext.first;
+		uint64_t value = reinterpret_cast<uint64_t>(ext.second);
+		result[key] = (godot::Variant)value;
+	}
+	return result;
+}
+
+void OpenXRStationaryReferenceSpaceExtension::_on_instance_created(uint64_t p_instance) {
+	if (stationary_reference_space_ext) {
+		bool result = initialize_stationary_reference_space_extension((XrInstance)p_instance);
+		if (!result) {
+			UtilityFunctions::print("Failed to initialize stationary_reference_space extension");
+			stationary_reference_space_ext = false;
+		}
+	}
+}
+
+void OpenXRStationaryReferenceSpaceExtension::_on_instance_destroyed() {
+	cleanup();
+}
+
+void OpenXRStationaryReferenceSpaceExtension::_on_session_created(uint64_t p_instance) {
+	if (!stationary_reference_space_ext) {
+		return;
+	}
+
+	XrReferenceSpaceCreateInfo create_info = {
+		XR_TYPE_REFERENCE_SPACE_CREATE_INFO, // type
+		nullptr, // next
+		XR_REFERENCE_SPACE_TYPE_STATIONARY_EXTX2, // referenceSpaceType
+		{ { 0.0f, 0.0f, 0.0f, 1.0f }, { 0.0f, 0.0f, 0.0f } } // poseInReferenceSpace
+	};
+
+	XrResult result = xrCreateReferenceSpace(SESSION, &create_info, &stationary_space);
+	if (XR_FAILED(result)) {
+		ERR_PRINT(vformat("OpenXR: Failed to create stationary space [%s]", get_openxr_api()->get_error_string(result)));
+		return;
+	}
+
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	ERR_FAIL_NULL(project_settings);
+
+	bool enable_on_startup = (bool)project_settings->get_setting_with_override("xr/openxr/extensions/stationary_reference_space/enable_on_startup");
+	if (enable_on_startup) {
+		set_stationary_reference_space_enabled(true);
+	}
+}
+
+void OpenXRStationaryReferenceSpaceExtension::set_stationary_reference_space_enabled(bool p_enable) {
+	if (!stationary_reference_space_ext) {
+		return;
+	}
+
+	if (p_enable) {
+		get_openxr_api()->set_custom_play_space(stationary_space);
+	} else {
+		get_openxr_api()->set_custom_play_space(XR_NULL_HANDLE);
+	}
+}
+
+StringName OpenXRStationaryReferenceSpaceExtension::get_stationary_reference_space_uuid() {
+	if (!stationary_reference_space_ext) {
+		return "";
+	}
+
+	XrStationaryReferenceSpaceIdResultEXTX2 stationary_reference_space_id_result = {
+		XR_TYPE_STATIONARY_REFERENCE_SPACE_ID_RESULT_EXTX2, // type
+		nullptr, // next
+		0 // generationId
+	};
+
+	XrResult result = xrGetStationaryReferenceSpaceIdEXTX2(SESSION, nullptr, &stationary_reference_space_id_result);
+	if (XR_FAILED(result)) {
+		ERR_PRINT(vformat("OpenXR: Failed to get stationary reference space ID [%s]", get_openxr_api()->get_error_string(result)));
+		return "";
+	}
+
+	StringName uuid_string_name = OpenXRUtilities::uuid_to_string_name(stationary_reference_space_id_result.generationId);
+	return uuid_string_name;
+}
+
+bool OpenXRStationaryReferenceSpaceExtension::is_stationary_reference_space_available() {
+	return stationary_reference_space_ext && (stationary_space != XR_NULL_HANDLE);
+}
+
+void OpenXRStationaryReferenceSpaceExtension::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_stationary_reference_space_enabled", "enable"), &OpenXRStationaryReferenceSpaceExtension::set_stationary_reference_space_enabled);
+
+	ClassDB::bind_method(D_METHOD("get_stationary_reference_space_uuid"), &OpenXRStationaryReferenceSpaceExtension::get_stationary_reference_space_uuid);
+
+	ClassDB::bind_method(D_METHOD("is_stationary_reference_space_available"), &OpenXRStationaryReferenceSpaceExtension::is_stationary_reference_space_available);
+}
+
+void OpenXRStationaryReferenceSpaceExtension::cleanup() {
+	stationary_reference_space_ext = false;
+
+	if (stationary_space != XR_NULL_HANDLE) {
+		xrDestroySpace(stationary_space);
+		stationary_space = XR_NULL_HANDLE;
+	}
+}
+
+bool OpenXRStationaryReferenceSpaceExtension::initialize_stationary_reference_space_extension(XrInstance p_instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrCreateReferenceSpace);
+	GDEXTENSION_INIT_XR_FUNC_V(xrDestroySpace);
+	GDEXTENSION_INIT_XR_FUNC_V(xrGetStationaryReferenceSpaceIdEXTX2);
+
+	return true;
+}
+#endif // META_HEADERS_ENABLED

--- a/plugin/src/main/cpp/include/extensions/openxr_stationary_reference_space_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_stationary_reference_space_extension.h
@@ -1,0 +1,93 @@
+/**************************************************************************/
+/*  openxr_stationary_reference_space_extension.h                         */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+// @todo GH Issue 304: Remove check for meta headers when feature becomes part of OpenXR spec.
+#ifdef META_HEADERS_ENABLED
+#pragma once
+
+#include <meta_openxr_preview/extx2_stationary_reference_space.h>
+#include <openxr/openxr.h>
+#include <godot_cpp/classes/open_xr_extension_wrapper.hpp>
+#include <map>
+
+#include "util.h"
+
+using namespace godot;
+
+class OpenXRStationaryReferenceSpaceExtension : public OpenXRExtensionWrapper {
+	GDCLASS(OpenXRStationaryReferenceSpaceExtension, OpenXRExtensionWrapper);
+
+public:
+	static OpenXRStationaryReferenceSpaceExtension *get_singleton();
+
+	OpenXRStationaryReferenceSpaceExtension();
+	~OpenXRStationaryReferenceSpaceExtension();
+
+	godot::Dictionary _get_requested_extensions(uint64_t p_xr_version) override;
+
+	void _on_instance_created(uint64_t p_instance) override;
+	void _on_instance_destroyed() override;
+	void _on_session_created(uint64_t p_instance) override;
+
+	void set_stationary_reference_space_enabled(bool p_enable);
+
+	StringName get_stationary_reference_space_uuid();
+
+	bool is_stationary_reference_space_available();
+
+protected:
+	static void _bind_methods();
+
+private:
+	EXT_PROTO_XRRESULT_FUNC3(xrCreateReferenceSpace,
+			(XrSession), session,
+			(const XrReferenceSpaceCreateInfo *), createInfo,
+			(XrSpace *), space)
+
+	EXT_PROTO_XRRESULT_FUNC1(xrDestroySpace,
+			(XrSpace), space)
+
+	EXT_PROTO_XRRESULT_FUNC3(xrGetStationaryReferenceSpaceIdEXTX2,
+			(XrSession), session,
+			(const XrStationaryReferenceSpaceIdGetInfoEXTX2 *), getInfo,
+			(XrStationaryReferenceSpaceIdResultEXTX2 *), result)
+
+	bool initialize_stationary_reference_space_extension(XrInstance p_instance);
+
+	void cleanup();
+
+	static OpenXRStationaryReferenceSpaceExtension *singleton;
+
+	std::map<godot::String, bool *> request_extensions;
+	bool stationary_reference_space_ext = false;
+
+	XrSpace stationary_space = XR_NULL_HANDLE;
+};
+
+#endif // META_HEADERS_ENABLED

--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -90,6 +90,7 @@
 #include "extensions/openxr_meta_simultaneous_hands_and_controllers_extension.h"
 #include "extensions/openxr_meta_spatial_entity_mesh_extension.h"
 #include "extensions/openxr_ml_marker_understanding_extension.h"
+#include "extensions/openxr_stationary_reference_space_extension.h"
 
 #include "classes/openxr_android_environment_depth.h"
 #include "classes/openxr_android_light_estimation.h"
@@ -215,6 +216,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 // @todo GH Issue 304: Remove check for meta headers when feature becomes part of OpenXR spec.
 #ifdef META_HEADERS_ENABLED
 			GDREGISTER_CLASS(OpenXRMetaBoundaryVisibilityExtension);
+			GDREGISTER_CLASS(OpenXRStationaryReferenceSpaceExtension);
 #endif // META_HEADERS_ENABLED
 
 			if (_get_bool_project_setting("xr/openxr/extensions/meta/passthrough")) {
@@ -307,6 +309,10 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			if (_get_bool_project_setting("xr/openxr/extensions/meta/boundary_visibility")) {
 				_register_extension_with_openxr(OpenXRMetaBoundaryVisibilityExtension::get_singleton());
 			}
+
+			if (_get_bool_project_setting("xr/openxr/extensions/stationary_reference_space")) {
+				_register_extension_with_openxr(OpenXRStationaryReferenceSpaceExtension::get_singleton());
+			}
 #endif // META_HEADERS_ENABLED
 
 			if (_get_bool_project_setting("xr/openxr/extensions/meta/colocation_discovery")) {
@@ -392,6 +398,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 // @todo GH Issue 304: Remove check for meta headers when feature becomes part of OpenXR spec.
 #ifdef META_HEADERS_ENABLED
 			_register_extension_as_singleton(OpenXRMetaBoundaryVisibilityExtension::get_singleton());
+			_register_extension_as_singleton(OpenXRStationaryReferenceSpaceExtension::get_singleton());
 #endif // META_HEADERS_ENABLED
 
 			GDREGISTER_CLASS(OpenXRAndroidLightEstimation);
@@ -566,6 +573,9 @@ void add_plugin_project_settings() {
 // @todo GH Issue 304: Remove check for meta headers when feature becomes part of OpenXR spec.
 #ifdef META_HEADERS_ENABLED
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/boundary_visibility", false);
+
+	_add_bool_project_setting(project_settings, "xr/openxr/extensions/stationary_reference_space", false);
+	_add_bool_project_setting(project_settings, "xr/openxr/extensions/stationary_reference_space/enable_on_startup", false);
 #endif // META_HEADERS_ENABLED
 
 	{


### PR DESCRIPTION
This PR builds on top of https://github.com/GodotVR/godot_openxr_vendors/pull/407 and will remain in draft until that PR is merged, at which point this could be merged into the 5.x branch.

This is another extension that relies on Meta OpenXR SDK headers, it's not currently in the OpenXR spec. When merged, it should be added to the issue used for tracking these: https://github.com/GodotVR/godot_openxr_vendors/issues/304

**Note:** In order for stationary reference space to work, you currently have to enable experimental features on your headset using `adb`:
```
adb shell setprop debug.oculus.experimentalEnabled 1
```

~~I've enabled the use of the stationary reference space in the Meta Scene Sample.~~ Seeing that the extension is not Meta-specific, I've made the project setting vendor neutral. I only added the manifest entry for it (enabling experimental features) in `meta_export_plugin.cpp`, I'm not aware if any other runtimes support it in this experimental stage.

**EDIT 2026-01-26:** I've removed enabling stationary reference space from the scene sample.