### PR TITLE
Add input handling to `viewport_2d_in_3d` and use fixed viewport size

### DIFF
--- a/demo/addons/common/function_pointer/function_pointer.gd
+++ b/demo/addons/common/function_pointer/function_pointer.gd
@@ -1,0 +1,180 @@
+extends Node3D
+
+const Viewport2Din3D = preload("res://addons/common/viewport_2d_in_3d/viewport_2d_in_3d.gd")
+
+@export var enabled := true:
+	set = set_enabled
+
+@export var select_action := "trigger_click"
+@export var select_pressed_threshold := 0.9
+@export var select_release_threshold := 0.6
+
+@export var show_when_intersecting := true:
+	set(v):
+		show_when_intersecting = v
+		_update_pointer_visibility()
+
+@export var released_material: Material:
+	set(v):
+		released_material = v
+		_update_pointer_material()
+
+@export var pressed_material: Material:
+	set(v):
+		pressed_material = v
+		_update_pointer_material()
+
+@export var pointer_length := 5.0
+@export var pointer_offset := 0.07
+
+@onready var _mesh_instance: MeshInstance3D = %MeshInstance3D
+
+var _controller: XRController3D
+var _cur_layer: Viewport2Din3D = null
+var _pressed := false
+
+
+func set_enabled(p_enabled: bool) -> void:
+	enabled = p_enabled
+	if not enabled and _cur_layer:
+		_cur_layer.pointer_leave(self)
+		_cur_layer = null
+	_update_pointer_visibility()
+	_update_pointer_material()
+
+
+func _ready() -> void:
+	_update_pointer_visibility()
+	_update_pointer_length(pointer_length)
+
+
+func _enter_tree() -> void:
+	var parent = get_parent()
+	if parent is XRController3D:
+		_controller = parent
+		_controller.input_float_changed.connect(_on_controller_input_float_changed)
+		_controller.button_pressed.connect(_on_controller_button_pressed)
+		_controller.button_released.connect(_on_controller_button_released)
+	else:
+		_controller = null
+
+
+func _exit_tree() -> void:
+	if _controller:
+		_controller.input_float_changed.disconnect(_on_controller_input_float_changed)
+		_controller.button_pressed.disconnect(_on_controller_button_pressed)
+		_controller.button_released.disconnect(_on_controller_button_released)
+
+
+func _process(_delta: float) -> void:
+	if enabled:
+		for layer in _get_ui_layers():
+			if not layer is Viewport2Din3D or not layer.visible:
+				continue
+			if layer.pointer_intersects(self):
+				if layer != _cur_layer:
+					if _cur_layer:
+						_cur_layer.pointer_leave(self)
+					_cur_layer = layer
+					_update_pointer_visibility()
+				break
+			elif _cur_layer == layer:
+				_cur_layer.pointer_leave(self)
+				_cur_layer = null
+				_update_pointer_visibility()
+				_update_pointer_length(pointer_length)
+
+
+func _get_ui_layers() -> Array:
+	if not is_inside_tree():
+		return []
+
+	var nodes := get_tree().get_nodes_in_group("ui_layer")
+
+	# Sort them closest to furthest.
+	if nodes.size() > 1:
+		var gp := global_position
+		nodes.sort_custom(func(a, b): return gp.distance_squared_to(a.global_position) < gp.distance_squared_to(b.global_position))
+
+	return nodes
+
+
+func _update_pointer_visibility() -> void:
+	if _mesh_instance:
+		_mesh_instance.visible = _check_pointer_visibility()
+
+
+func _check_pointer_visibility() -> bool:
+	if not enabled:
+		return false
+
+	if show_when_intersecting and not _cur_layer:
+		return false
+
+	return true
+
+
+func _update_pointer_length(p_length: float) -> void:
+	if _mesh_instance:
+		_mesh_instance.mesh.size.z = p_length
+		_mesh_instance.position.z = -(p_length / 2.0) - pointer_offset
+
+
+func _update_pointer_length_for_intersection(p_intersection: Vector3) -> void:
+	var length := (p_intersection - global_position).length() - pointer_offset
+	if length <= 0 or length > pointer_length:
+		length = pointer_length
+	_update_pointer_length(length)
+
+
+func _update_pointer_material() -> void:
+	if _mesh_instance:
+		_mesh_instance.set_surface_override_material(0, pressed_material if _pressed else released_material)
+
+
+func _on_controller_input_float_changed(p_name: String, p_value: float) -> void:
+	if p_name == select_action:
+		if not _pressed and p_value > select_pressed_threshold:
+			_pressed = true
+			_update_pointer_material()
+			if _cur_layer:
+				_cur_layer.pointer_set_pressed(self, true)
+		elif _pressed and p_value < select_release_threshold:
+			_pressed = false
+			_update_pointer_material()
+			if _cur_layer:
+				_cur_layer.pointer_set_pressed(self, false)
+
+
+func _do_select_press() -> void:
+	_pressed = true
+	_update_pointer_material()
+	if _cur_layer:
+		_cur_layer.pointer_set_pressed(self, true)
+
+
+func _do_select_release() -> void:
+	_pressed = false
+	_update_pointer_material()
+	if _cur_layer:
+		_cur_layer.pointer_set_pressed(self, false)
+
+
+func _on_controller_button_pressed(p_name: String) -> void:
+	if p_name == select_action:
+		_do_select_press()
+
+
+func _on_controller_button_released(p_name: String) -> void:
+	if p_name == select_action:
+		_do_select_release()
+
+
+func _get_hand_index() -> int:
+	if _controller:
+		match _controller.tracker:
+			"left_hand":
+				return 0
+			"right_hand":
+				return 1
+	return -1

--- a/demo/addons/common/function_pointer/function_pointer.gd.uid
+++ b/demo/addons/common/function_pointer/function_pointer.gd.uid
@@ -1,0 +1,1 @@
+uid://qe5cwrdl7ri2

--- a/demo/addons/common/function_pointer/function_pointer.tscn
+++ b/demo/addons/common/function_pointer/function_pointer.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=5 format=3 uid="uid://cqs8c3rq6cxvk"]
+
+[ext_resource type="Script" uid="uid://qe5cwrdl7ri2" path="res://addons/common/function_pointer/function_pointer.gd" id="1_pjipa"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_pjipa"]
+shading_mode = 0
+disable_receive_shadows = true
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_g1l7f"]
+shading_mode = 0
+albedo_color = Color(0, 0.478431, 1, 1)
+disable_receive_shadows = true
+
+[sub_resource type="BoxMesh" id="BoxMesh_6h6mo"]
+resource_local_to_scene = true
+size = Vector3(0.005, 0.005, 5)
+
+[node name="FunctionPointer" type="Node3D" groups=["function_pointer"]]
+script = ExtResource("1_pjipa")
+select_action = "trigger"
+released_material = SubResource("StandardMaterial3D_pjipa")
+pressed_material = SubResource("StandardMaterial3D_g1l7f")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -2.57)
+mesh = SubResource("BoxMesh_6h6mo")
+skeleton = NodePath("../../LeftHand")
+surface_material_override/0 = SubResource("StandardMaterial3D_pjipa")

--- a/demo/addons/common/view_pivot/view_pivot.gd
+++ b/demo/addons/common/view_pivot/view_pivot.gd
@@ -1,0 +1,124 @@
+extends Node3D
+
+## The minimum threshold that the dot product between the camera direction
+## and desired direction must fall below before the pivot is rotated.
+## Higher values will rotate more often, and lower values will be looser.
+@export var direction_threshold := 0.9
+
+## The minimum threshold that the distance between the camera position and
+## desired position must go above, before the pivot is moved.
+## Lower values will move more often, and higher values will be looser.
+@export var distance_threshold := 0.5
+
+## The delay (in seconds) after the camera has moved past one of the thresholds
+## before the pivot will move.
+@export var movement_delay := 1.0:
+	set = set_movement_delay
+
+@onready var _timer: Timer = %Timer
+
+var _current_direction: Vector3 = Vector3.FORWARD
+var _current_position: Vector3
+var _pivot_transform: Transform3D
+
+
+func set_movement_delay(p_delay: float) -> void:
+	movement_delay = p_delay
+	if _timer != null:
+		_timer.wait_time = movement_delay
+
+
+func _ready() -> void:
+	_timer.wait_time = movement_delay
+	update_transform_immediately()
+	set_process(is_visible_in_tree())
+
+
+func _get_camera() -> XRCamera3D:
+	var vp: Viewport = get_viewport()
+	if vp == null:
+		return null
+
+	var camera: Camera3D = vp.get_camera_3d()
+	if camera == null or not camera is XRCamera3D:
+		return null
+
+	return camera as XRCamera3D
+
+
+func _get_camera_direction() -> Vector3:
+	var camera: XRCamera3D = _get_camera()
+	if camera == null:
+		return _current_direction
+
+	var v: Vector3 = -camera.global_transform.basis.z
+
+	# If the player is looking straight up or down, use the current direction.
+	if is_equal_approx(abs(v.y), 1.0):
+		return _current_direction
+
+	v.y = 0
+	v = v.normalized()
+
+	return v
+
+
+func _get_camera_position() -> Vector3:
+	var camera: XRCamera3D = _get_camera()
+	if camera == null:
+		return _current_direction
+
+	return camera.global_position
+
+
+func update_transform_immediately() -> void:
+	_current_direction = _get_camera_direction()
+	_current_position = _get_camera_position()
+	_pivot_transform.origin = Vector3(_current_position.x, 0.0, _current_position.z)
+	_pivot_transform.basis = Basis.looking_at(_current_direction)
+	_update_transform()
+
+
+func _update_transform() -> void:
+	global_transform = _pivot_transform
+
+
+func _process(_delta: float) -> void:
+	if visible:
+		var camera_direction := _get_camera_direction()
+		var camera_distance := (_current_position - _get_camera_position()).length()
+		if _current_direction.dot(camera_direction) < direction_threshold or camera_distance > distance_threshold:
+			if _timer.is_stopped():
+				_timer.start()
+		else:
+			_timer.stop()
+
+
+func _notification(p_what: int) -> void:
+	match p_what:
+		NOTIFICATION_VISIBILITY_CHANGED:
+			if is_visible_in_tree():
+				update_transform_immediately()
+				set_process(true)
+			else:
+				set_process(false)
+
+
+func _on_timer_timeout() -> void:
+	_current_position = _get_camera_position()
+	_current_direction = _get_camera_direction()
+	var new_basis = Basis.looking_at(_current_direction)
+
+	var pivot_tween = get_tree().create_tween()
+	pivot_tween.tween_method(self._tween_pivot_transform_basis, _pivot_transform.basis.get_rotation_quaternion(), new_basis.get_rotation_quaternion(), 1.0).set_trans(Tween.TRANS_EXPO).set_ease(Tween.EASE_OUT)
+	pivot_tween.parallel().tween_method(self._tween_pivot_transform_origin, _pivot_transform.origin, Vector3(_current_position.x, 0.0, _current_position.z), 1.0).set_trans(Tween.TRANS_EXPO).set_ease(Tween.EASE_OUT)
+
+
+func _tween_pivot_transform_basis(p_rotation: Quaternion) -> void:
+	_pivot_transform.basis = Basis(p_rotation)
+	_update_transform()
+
+
+func _tween_pivot_transform_origin(p_origin: Vector3) -> void:
+	_pivot_transform.origin = p_origin
+	_update_transform()

--- a/demo/addons/common/view_pivot/view_pivot.gd.uid
+++ b/demo/addons/common/view_pivot/view_pivot.gd.uid
@@ -1,0 +1,1 @@
+uid://1nit8ovimkj4

--- a/demo/addons/common/view_pivot/view_pivot.tscn
+++ b/demo/addons/common/view_pivot/view_pivot.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3 uid="uid://xga880omsrpm"]
+
+[ext_resource type="Script" uid="uid://1nit8ovimkj4" path="res://addons/common/view_pivot/view_pivot.gd" id="1_tpea8"]
+
+[node name="ViewPivot" type="Node3D"]
+script = ExtResource("1_tpea8")
+
+[node name="Timer" type="Timer" parent="."]
+unique_name_in_owner = true
+one_shot = true
+
+[connection signal="timeout" from="Timer" to="." method="_on_timer_timeout"]

--- a/demo/addons/common/viewport_2d_in_3d/cursor.svg
+++ b/demo/addons/common/viewport_2d_in_3d/cursor.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866666"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="cursor.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-units="px"
+     showgrid="false"
+     units="px"
+     inkscape:zoom="1.5554293"
+     inkscape:cx="-117.0095"
+     inkscape:cy="46.289472"
+     inkscape:window-width="2556"
+     inkscape:window-height="1397"
+     inkscape:window-x="1920"
+     inkscape:window-y="20"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <circle
+       style="fill:#ffffff;stroke-width:0.25;stroke-linecap:round;stroke-linejoin:round;fill-opacity:1"
+       id="path846"
+       cx="16.933332"
+       cy="16.933332"
+       r="15.610416" />
+  </g>
+</svg>

--- a/demo/addons/common/viewport_2d_in_3d/cursor.svg.import
+++ b/demo/addons/common/viewport_2d_in_3d/cursor.svg.import
@@ -1,0 +1,45 @@
+[remap]
+
+importer="texture"
+type="CompressedTexture2D"
+uid="uid://ygh2w2bgty4x"
+path.s3tc="res://.godot/imported/cursor.svg-d8f962c18d5061feed8ef3007fdd0964.s3tc.ctex"
+path.etc2="res://.godot/imported/cursor.svg-d8f962c18d5061feed8ef3007fdd0964.etc2.ctex"
+metadata={
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
+"vram_texture": true
+}
+
+[deps]
+
+source_file="res://addons/common/viewport_2d_in_3d/cursor.svg"
+dest_files=["res://.godot/imported/cursor.svg-d8f962c18d5061feed8ef3007fdd0964.s3tc.ctex", "res://.godot/imported/cursor.svg-d8f962c18d5061feed8ef3007fdd0964.etc2.ctex"]
+
+[params]
+
+compress/mode=2
+compress/high_quality=false
+compress/lossy_quality=0.7
+compress/uastc_level=0
+compress/rdo_quality_loss=0.0
+compress/hdr_compression=1
+compress/normal_map=0
+compress/channel_pack=0
+mipmaps/generate=true
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
+process/channel_remap/red=0
+process/channel_remap/green=1
+process/channel_remap/blue=2
+process/channel_remap/alpha=3
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=0
+svg/scale=1.0
+editor/scale_with_editor_scale=false
+editor/convert_colors_with_editor_theme=false

--- a/demo/addons/common/viewport_2d_in_3d/viewport_2d_in_3d.gd
+++ b/demo/addons/common/viewport_2d_in_3d/viewport_2d_in_3d.gd
@@ -5,12 +5,11 @@ extends Node3D
 ##
 ## This node is currently intended to be a more flexible version of [Label3D], since it essentially
 ## enables Godot's full [Control] node ui capability for 3D space.
-##
-## Note that input is ignored (and a lot of work is required if we want input)
 
-## Signal called when the underlying quad mesh's size changes.[br]
-## Call [method get_size] to get the new size.
-signal resized
+const NO_INTERSECTION = Vector2(-1.0, -1.0)
+const CURSOR_DISTANCE = 0.005
+const DOUBLE_CLICK_TIME = 400
+const DOUBLE_CLICK_DIST = 5.0
 
 ## The current [PackedScene] rendered by the quad.[br]
 ## The [PackedScene]'s root node must be a [Control] node.[br]
@@ -18,11 +17,15 @@ signal resized
 @export var scene: PackedScene:
 	set = set_scene
 
+## The viewport size in pixels.
+@export var viewport_size := Vector2i(1152, 648):
+	set = set_viewport_size
+
 ## 1 pixel in 2D space is this size, in meters, in 3D space.[br]
 ## The default chosen here results in the best text rendering (though the font will need to be
 ## oversampled)[br]
 ## Example:[br]
-## a [code]200x300pixel[/code] scene in 2D, when [param pixel_size] is [code]0.0001[/code],
+## with a [code]viewport_size[/code] of 200 x 300 pixels when [param pixel_size] is [code]0.0001[/code],
 ## is 0.02x0.03meters in 3D space.
 @export var pixel_size := 0.0001:
 	set = set_pixel_size
@@ -41,6 +44,14 @@ signal resized
 
 var _scene_root: Control
 
+var _pointer: Node3D
+var _pointer_pressed := false
+var _prev_intersection: Vector2 = NO_INTERSECTION
+var _prev_pressed_pos: Vector2
+var _prev_pressed_time: int = 0
+
+@onready var _quad: MeshInstance3D = $Quad
+@onready var _cursor: MeshInstance3D = $Cursor
 @onready var _viewport: SubViewport = $SubViewport
 
 
@@ -49,10 +60,17 @@ func _ready():
 	# may be unexpected, and setters may not have been called (which happens for values not set in the
 	# inspector)
 	_try_to_add_scene_root_to_viewport()
-	set_pixel_size(pixel_size)
+	_update_sizes()
 	set_render_priority(render_priority)
 	set_no_depth_test(no_depth_test)
 	set_modulate_color(modulate_color)
+
+
+func _update_sizes() -> void:
+	if _viewport and _viewport.size != viewport_size:
+		_viewport.size = viewport_size
+	if _quad:
+		_quad.mesh.size = viewport_size * pixel_size
 
 
 ## Set a new 2D scene resource as the scene to render.[br]
@@ -66,7 +84,6 @@ func set_scene(new_scene: PackedScene):
 			return
 
 	if _scene_root != null:
-		_scene_root.resized.disconnect(set_pixel_size.bind(pixel_size))
 		_scene_root.queue_free()
 		_scene_root = null
 
@@ -74,7 +91,11 @@ func set_scene(new_scene: PackedScene):
 	_scene_root = new_scene_root
 
 	_try_to_add_scene_root_to_viewport()
-	set_pixel_size(pixel_size)
+
+
+func set_viewport_size(new_viewport_size: Vector2i) -> void:
+	viewport_size = new_viewport_size
+	_update_sizes()
 
 
 func set_pixel_size(new_pixel_size: float):
@@ -82,37 +103,32 @@ func set_pixel_size(new_pixel_size: float):
 		printerr("pixel size must be >= 0")
 		return
 
-	# always set the pixel size, and always attempt to set the size, since maybe
-	# _scene_root wasn't ready the first time set_pixel_size() was called during initialization
 	pixel_size = new_pixel_size
-
-	if is_inside_tree() && _scene_root != null:
-		$MeshInstance3D.mesh.size = _scene_root.size * pixel_size
-		resized.emit()
+	_update_sizes()
 
 
 func set_render_priority(new_render_priority: int):
 	render_priority = new_render_priority
-	if !is_inside_tree():
+	if not _quad:
 		return
 
-	$MeshInstance3D.mesh.material.render_priority = render_priority
+	_quad.mesh.material.render_priority = render_priority
 
 
 func set_no_depth_test(new_no_depth_test: bool):
 	no_depth_test = new_no_depth_test
-	if !is_inside_tree():
+	if not _quad:
 		return
 
-	$MeshInstance3D.mesh.material.no_depth_test = no_depth_test
+	_quad.mesh.material.no_depth_test = no_depth_test
 
 
 func set_modulate_color(new_modulate_color: Color):
 	modulate_color = new_modulate_color
-	if !is_inside_tree():
+	if not _quad:
 		return
 
-	$MeshInstance3D.mesh.material.albedo_color = modulate_color
+	_quad.mesh.material.albedo_color = modulate_color
 
 
 ## Get the root node of the 2D scene rendered in the 3D quad.[br]
@@ -124,7 +140,9 @@ func get_scene_root() -> Control:
 ## Get the size of the 3D Quad, in meters, where [member Vector2.x]
 ## is the width and [member Vector2.y] is the height
 func get_size() -> Vector2:
-	return $MeshInstance3D.mesh.size if is_inside_tree() && _scene_root != null else Vector2.ZERO
+	if _quad:
+		return _quad.mesh.size
+	return Vector2.ZERO
 
 
 func _try_to_add_scene_root_to_viewport():
@@ -132,18 +150,148 @@ func _try_to_add_scene_root_to_viewport():
 		return
 
 	_viewport.add_child(_scene_root)
-	_viewport.size = _scene_root.size
-
-	# resize the mesh any time the root node resizes (so that the mesh grows/shrinks as needed)
-	_scene_root.resized.connect(_on_scene_root_resized)
 
 
-func _on_scene_root_resized():
-	# _scene_root should be non-null since _on_scene_root_resized is only called when we receive a
-	# signal from it
-	if _scene_root == null:
-		printerr("Unexpected; how did we get a signal from _scene_root when it is null?")
+func _intersect_to_global_pos(p_intersection: Vector2, p_distance: float = 0.0) -> Vector3:
+	if p_intersection != NO_INTERSECTION:
+		var local_pos: Vector2 = (p_intersection - Vector2(0.5, 0.5)) * get_size()
+		return global_transform * Vector3(local_pos.x, -local_pos.y, p_distance)
+
+	return Vector3()
+
+
+func _intersect_to_viewport_pos(p_intersection: Vector2) -> Vector2:
+	if _viewport and p_intersection != NO_INTERSECTION:
+		var pos: Vector2 = p_intersection * Vector2(_viewport.size)
+		return Vector2(pos)
+
+	return NO_INTERSECTION
+
+
+func intersects_ray(p_origin: Vector3, p_direction: Vector3) -> Vector2:
+	if not visible:
+		return NO_INTERSECTION
+
+	var quad_transform: Transform3D = get_global_transform()
+	var quad_normal: Vector3 = quad_transform.basis.z
+
+	var denom: float = quad_normal.dot(p_direction)
+	if absf(denom) > 0.0001:
+		var vector: Vector3 = quad_transform.origin - p_origin
+		var t: float = vector.dot(quad_normal) / denom
+		if t < 0.0:
+			return NO_INTERSECTION
+
+		var intersection: Vector3 = p_origin + p_direction * t
+
+		var relative_point: Vector3 = intersection - quad_transform.origin
+		var projected_point := Vector2(relative_point.dot(quad_transform.basis.x), relative_point.dot(quad_transform.basis.y))
+
+		var quad_size := get_size()
+		if absf(projected_point.x) > quad_size.x / 2.0:
+			return NO_INTERSECTION
+		if absf(projected_point.y) > quad_size.y / 2.0:
+			return NO_INTERSECTION
+
+		var u: float = 0.5 + (projected_point.x / quad_size.x)
+		var v: float = 1.0 - (0.5 + (projected_point.y / quad_size.y))
+
+		return Vector2(u, v)
+
+	return NO_INTERSECTION
+
+
+func pointer_intersects(p_pointer: Node3D) -> bool:
+	var pt := p_pointer.global_transform
+	var intersection := intersects_ray(pt.origin, -pt.basis.z)
+	if intersection != NO_INTERSECTION:
+		# If there was no current pointer, let's take this one.
+		if _pointer == null:
+			_pointer = p_pointer
+			_cursor.visible = true
+
+		var cursor_position = _intersect_to_global_pos(intersection, CURSOR_DISTANCE)
+		if p_pointer.has_method("_update_pointer_length_for_intersection"):
+			p_pointer._update_pointer_length_for_intersection(cursor_position)
+
+		# If this pointer is the current pointer, then the cursor and mouse events move with it.
+		if p_pointer == _pointer:
+			_cursor.global_position = cursor_position
+
+			if _viewport and _prev_intersection:
+				var event := InputEventMouseMotion.new()
+				var from := _intersect_to_viewport_pos(_prev_intersection)
+				var to := _intersect_to_viewport_pos(intersection)
+				if _pointer_pressed:
+					event.button_mask = MOUSE_BUTTON_MASK_LEFT
+				event.relative = to - from
+				event.position = to
+				_viewport.push_input(event)
+
+			_prev_intersection = intersection
+
+		return true
+
+	# If this pointer is the current pointer, but there was no intersection, then that pointer
+	# should leave.
+	if p_pointer == _pointer:
+		# Except if it's pressed - we'll hang on to it until it's released.
+		if _pointer_pressed:
+			return true
+		pointer_leave(p_pointer)
+
+	return false
+
+
+func _send_mouse_button_event(p_pressed: bool) -> void:
+	if not _viewport:
 		return
 
-	_viewport.size = _scene_root.size
-	set_pixel_size(pixel_size)
+	var event := InputEventMouseButton.new()
+	event.button_index = MOUSE_BUTTON_LEFT
+	event.button_mask = MOUSE_BUTTON_MASK_LEFT
+	event.pressed = p_pressed
+	event.position = _intersect_to_viewport_pos(_prev_intersection)
+
+	if p_pressed:
+		var time := Time.get_ticks_msec()
+		if time - _prev_pressed_time < DOUBLE_CLICK_TIME and (event.position - _prev_pressed_pos).length() < DOUBLE_CLICK_DIST:
+			event.double_click = true
+
+		_prev_pressed_time = time
+		_prev_pressed_pos = event.position
+
+	_viewport.push_input(event)
+
+
+func pointer_leave(p_pointer: Node3D) -> void:
+	# We only need to do anything, if the pointer leaving is the current pointer.
+	if _pointer == p_pointer:
+		# If the pointer was pressed, then send the mouse event to release the button.
+		if _pointer_pressed and _prev_intersection != NO_INTERSECTION:
+			_send_mouse_button_event(false)
+
+		# And clear everything out.
+		_pointer = null
+		_pointer_pressed = false
+		_cursor.visible = false
+		_prev_intersection = NO_INTERSECTION
+		_prev_pressed_time = 0
+
+
+func pointer_set_pressed(p_pointer: Node3D, p_pressed: bool) -> void:
+	if p_pointer == _pointer:
+		# If this is the current pointer, then update our pressed state and send the mouse
+		# events, if this is a change in state.
+		if p_pressed != _pointer_pressed:
+			_pointer_pressed = p_pressed
+			_send_mouse_button_event(p_pressed)
+	elif p_pressed:
+		# If another pointer presses, then allow it to take over.
+		if _pointer:
+			# The current pointer leaves (this will send the mouse up event).
+			pointer_leave(_pointer)
+		if pointer_intersects(p_pointer):
+			_pointer_pressed = true
+			_prev_pressed_time = 0
+			_send_mouse_button_event(true)

--- a/demo/addons/common/viewport_2d_in_3d/viewport_2d_in_3d.tscn
+++ b/demo/addons/common/viewport_2d_in_3d/viewport_2d_in_3d.tscn
@@ -1,6 +1,18 @@
-[gd_scene load_steps=5 format=3 uid="uid://dcwibwtseri8h"]
+[gd_scene load_steps=8 format=3 uid="uid://dcwibwtseri8h"]
 
 [ext_resource type="Script" uid="uid://ch5we601n513i" path="res://addons/common/viewport_2d_in_3d/viewport_2d_in_3d.gd" id="1_cglsv"]
+[ext_resource type="Texture2D" uid="uid://ygh2w2bgty4x" path="res://addons/common/viewport_2d_in_3d/cursor.svg" id="2_of46t"]
+
+[sub_resource type="QuadMesh" id="QuadMesh_5sc1k"]
+size = Vector2(0.03, 0.03)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_3y723"]
+transparency = 1
+shading_mode = 0
+disable_ambient_light = true
+disable_fog = true
+albedo_color = Color(0.7411765, 0.7411765, 0.7411765, 1)
+albedo_texture = ExtResource("2_of46t")
 
 [sub_resource type="ViewportTexture" id="ViewportTexture_numi8"]
 viewport_path = NodePath("SubViewport")
@@ -14,14 +26,21 @@ albedo_texture = SubResource("ViewportTexture_numi8")
 [sub_resource type="QuadMesh" id="QuadMesh_rd55w"]
 resource_local_to_scene = true
 material = SubResource("StandardMaterial3D_ej13h")
+size = Vector2(0.1152, 0.0648)
 
-[node name="Viewport2Din3D" type="Node3D"]
+[node name="Viewport2Din3D" type="Node3D" groups=["ui_layer"]]
 script = ExtResource("1_cglsv")
 
-[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+[node name="Cursor" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0.005)
+visible = false
+mesh = SubResource("QuadMesh_5sc1k")
+surface_material_override/0 = SubResource("StandardMaterial3D_3y723")
+
+[node name="Quad" type="MeshInstance3D" parent="."]
 mesh = SubResource("QuadMesh_rd55w")
 
 [node name="SubViewport" type="SubViewport" parent="."]
 disable_3d = true
 transparent_bg = true
-snap_2d_vertices_to_pixel = true
+size = Vector2i(1152, 648)

--- a/samples/androidxr-depth-texture-sample/2D/Quad.tscn
+++ b/samples/androidxr-depth-texture-sample/2D/Quad.tscn
@@ -5,9 +5,11 @@ bg_color = Color(1, 1, 0, 1)
 
 [node name="Quad" type="Label"]
 custom_minimum_size = Vector2(400, 400)
-anchors_preset = -1
-offset_right = 219.0
-offset_bottom = 99.0
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_font_sizes/font_size = 72
 theme_override_styles/normal = SubResource("StyleBoxFlat_v3yho")

--- a/samples/androidxr-depth-texture-sample/main.tscn
+++ b/samples/androidxr-depth-texture-sample/main.tscn
@@ -30,6 +30,7 @@ environment = SubResource("Environment_tep2q")
 [node name="Viewport2Din3D" parent="XROrigin3D/XRCamera3D" instance=ExtResource("2_h2yge")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.5)
 scene = ExtResource("3_1bvp3")
+viewport_size = Vector2i(512, 512)
 pixel_size = 0.0010000000038417
 
 [node name="Timer" type="Timer" parent="."]


### PR DESCRIPTION
In our samples, traditionally, we've used controller buttons to toggle settings.

However, on Samsung Galaxy XR, folks may not have controllers at all!

In order to make settings easier in that context, I thought it would be good to have input on our implementation of `viewport_2d_in_3d`, so we can pinch select UI controls there (or use controllers too). So, I stole some code from [my personal version of `viewport_2d_in_3d`](https://gitlab.com/snopek-games/sgxr/-/blob/main/addons/sgxr/ui_layer/ui_layer.gd?ref_type=heads) and some other bits and pieces to implement this. (I didn't bring everything over - I removed the use of `OpenXRCompositionLayer`s and the support for WebXR.)

Also, this PR removes all the stuff that tried to have automatic viewport sizing and replaces it with an property for viewport size.

The previous implementation had some "circular problems": it was grabbing the size of the control it added to the viewport, and then resizing the viewport to that - but the size of the control _depends_ on the size of its parent viewport! I don't think there's a way to truly do automatic sizing without doing it "iteratively" somehow, and that seems like way too much - we can just give it an explicit size and be done with it :-)