### PR TITLE
Update environment_depth.rst with permissions info. Fix code typo.

### DIFF
--- a/docs/manual/meta/environment_depth.rst
+++ b/docs/manual/meta/environment_depth.rst
@@ -24,7 +24,7 @@ Before Meta Environment Depth can be used, it needs to be started:
 	if OpenXRMetaEnvironmentDepthExtensionWrapper.is_environment_depth_supported():
 		OpenXRMetaEnvironmentDepthExtensionWrapper.start_environment_depth()
 
-This will only work if there is both an active OpenXR session, and relevant Android permissions have all been granted in advance of the call. Namely, explicitly, "dangerous" permission ``android.permission.CAMERA``, and runtime permission ``USE_SCENE``. The latter can be automatically requested via the extension settings, Project Settings > OpenXR > Extensions > Automatically Request Runtime Permissions, or explicitly in code like the camera one.
+This will only work if there is an active OpenXR session. You can connect to the ``OpenXRInterface.session_begun`` signal to run code right when the session starts.
 
 There is a performance cost to using Meta Environment Depth, so you should only start it when needed, and stop it when no longer needed. For example, if your application has both a VR and AR mode, you should make sure that Meta Environment Depth is only running in AR mode.
 


### PR DESCRIPTION
Picked up on a couple of typos discovered when I tried to actually follow the documented "Accessing the depth map on the CPU" example as a jumping off point for my project.

Clarified requirements for using Meta Environment Depth / OpenXRMetaEnvironmentDepthExtensionWrapper.start_environment_depth(); including necessary Android permissions.

With those in mind, veered away from the prior suggestion of triggering start_environment_depth() via the OpenXRInterface,session_began signal. As, surely, attempting to secure the permissions before the session has started will - at best - flood the logs with Condition "image_acquired" is true. Returning: true errors [<C++ Source>  modules/openxr/openxr_api.cpp:175 @ acquire()]?

//sigh// The legacy of evolving Android permissions - with or without Godot! - is such a ballache! 😜 