### PR TITLE
Implement XR_ANDROID_unbounded_reference_space

### DIFF
--- a/doc_classes/OpenXRAndroidUnboundedReferenceSpaceExtension.xml
+++ b/doc_classes/OpenXRAndroidUnboundedReferenceSpaceExtension.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRAndroidUnboundedReferenceSpaceExtension" inherits="OpenXRExtensionWrapper" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Wraps the [code]XR_ANDROID_unbounded_reference_space[/code] extension.
+	</brief_description>
+	<description>
+		Wraps the [code]XR_ANDROID_unbounded_reference_space[/code] extension.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="is_play_space_unbounded">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if play space is set to unbounded reference space.
+			</description>
+		</method>
+		<method name="is_unbounded_reference_space_available">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if unbounded reference space is available for use.
+			</description>
+		</method>
+		<method name="set_unbounded_reference_space_enabled">
+			<return type="void" />
+			<param index="0" name="enable" type="bool" />
+			<description>
+				Sets the unbounded reference space as enabled or disabled.
+				Note: The AndroidXR Unbounded Reference Space project setting must be enabled in order to enable the reference space.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/plugin/src/main/cpp/extensions/openxr_android_unbounded_reference_space.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_unbounded_reference_space.cpp
@@ -1,0 +1,155 @@
+/**************************************************************************/
+/*  openxr_android_unbounded_reference_space_extension.cpp                */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "extensions/openxr_android_unbounded_reference_space_extension.h"
+
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/xr_interface.hpp>
+#include <godot_cpp/classes/xr_server.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+OpenXRAndroidUnboundedReferenceSpaceExtension *OpenXRAndroidUnboundedReferenceSpaceExtension::singleton = nullptr;
+
+OpenXRAndroidUnboundedReferenceSpaceExtension *OpenXRAndroidUnboundedReferenceSpaceExtension::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRAndroidUnboundedReferenceSpaceExtension());
+	}
+	return singleton;
+}
+
+OpenXRAndroidUnboundedReferenceSpaceExtension::OpenXRAndroidUnboundedReferenceSpaceExtension() :
+		OpenXRExtensionWrapper() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRAndroidUnboundedReferenceSpaceExtension singleton already exists.");
+
+	request_extensions[XR_ANDROID_UNBOUNDED_REFERENCE_SPACE_EXTENSION_NAME] = &androidxr_unbounded_reference_space_ext;
+	singleton = this;
+}
+
+OpenXRAndroidUnboundedReferenceSpaceExtension::~OpenXRAndroidUnboundedReferenceSpaceExtension() {
+	cleanup();
+	singleton = nullptr;
+}
+
+godot::Dictionary OpenXRAndroidUnboundedReferenceSpaceExtension::_get_requested_extensions(uint64_t p_xr_version) {
+	godot::Dictionary result;
+	for (auto ext : request_extensions) {
+		godot::String key = ext.first;
+		uint64_t value = reinterpret_cast<uint64_t>(ext.second);
+		result[key] = (godot::Variant)value;
+	}
+	return result;
+}
+
+void OpenXRAndroidUnboundedReferenceSpaceExtension::_on_instance_created(uint64_t p_instance) {
+	if (androidxr_unbounded_reference_space_ext) {
+		bool result = initialize_androidxr_unbounded_reference_space_extension((XrInstance)p_instance);
+		if (!result) {
+			UtilityFunctions::print("Failed to initialize androidxr_unbounded_reference_space extension");
+			androidxr_unbounded_reference_space_ext = false;
+		}
+	}
+}
+
+void OpenXRAndroidUnboundedReferenceSpaceExtension::_on_instance_destroyed() {
+	cleanup();
+}
+
+void OpenXRAndroidUnboundedReferenceSpaceExtension::_on_session_created(uint64_t p_instance) {
+	if (!androidxr_unbounded_reference_space_ext) {
+		return;
+	}
+
+	XrReferenceSpaceCreateInfo create_info = {
+		XR_TYPE_REFERENCE_SPACE_CREATE_INFO, // type
+		nullptr, // next
+		XR_REFERENCE_SPACE_TYPE_UNBOUNDED_ANDROID, // referenceSpaceType
+		{ { 0.0f, 0.0f, 0.0f, 1.0f }, { 0.0f, 0.0f, 0.0f } } // poseInReferenceSpace
+	};
+
+	XrResult result = xrCreateReferenceSpace(SESSION, &create_info, &unbounded_space);
+	if (XR_FAILED(result)) {
+		ERR_PRINT(vformat("OpenXR: Failed to create unbounded space [%s]", get_openxr_api()->get_error_string(result)));
+		return;
+	}
+
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	ERR_FAIL_NULL(project_settings);
+
+	bool enable_on_startup = (bool)project_settings->get_setting_with_override("xr/openxr/extensions/androidxr/unbounded_reference_space/enable_on_startup");
+	if (enable_on_startup) {
+		set_unbounded_reference_space_enabled(true);
+	}
+}
+
+void OpenXRAndroidUnboundedReferenceSpaceExtension::set_unbounded_reference_space_enabled(bool p_enable) {
+	if (!androidxr_unbounded_reference_space_ext) {
+		return;
+	}
+
+	if (p_enable) {
+		get_openxr_api()->set_custom_play_space(unbounded_space);
+	} else {
+		get_openxr_api()->set_custom_play_space(XR_NULL_HANDLE);
+	}
+}
+
+bool OpenXRAndroidUnboundedReferenceSpaceExtension::is_unbounded_reference_space_available() {
+	return androidxr_unbounded_reference_space_ext && (unbounded_space != XR_NULL_HANDLE);
+}
+
+bool OpenXRAndroidUnboundedReferenceSpaceExtension::is_play_space_unbounded() {
+	return get_openxr_api()->get_play_space() == reinterpret_cast<uint64_t>(unbounded_space);
+}
+
+void OpenXRAndroidUnboundedReferenceSpaceExtension::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_unbounded_reference_space_enabled", "enable"), &OpenXRAndroidUnboundedReferenceSpaceExtension::set_unbounded_reference_space_enabled);
+
+	ClassDB::bind_method(D_METHOD("is_unbounded_reference_space_available"), &OpenXRAndroidUnboundedReferenceSpaceExtension::is_unbounded_reference_space_available);
+
+	ClassDB::bind_method(D_METHOD("is_play_space_unbounded"), &OpenXRAndroidUnboundedReferenceSpaceExtension::is_play_space_unbounded);
+}
+
+void OpenXRAndroidUnboundedReferenceSpaceExtension::cleanup() {
+	androidxr_unbounded_reference_space_ext = false;
+
+	if (unbounded_space != XR_NULL_HANDLE) {
+		xrDestroySpace(unbounded_space);
+		unbounded_space = XR_NULL_HANDLE;
+	}
+}
+
+bool OpenXRAndroidUnboundedReferenceSpaceExtension::initialize_androidxr_unbounded_reference_space_extension(XrInstance p_instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrCreateReferenceSpace);
+	GDEXTENSION_INIT_XR_FUNC_V(xrDestroySpace);
+
+	return true;
+}

--- a/plugin/src/main/cpp/include/extensions/openxr_android_unbounded_reference_space_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_android_unbounded_reference_space_extension.h
@@ -1,0 +1,83 @@
+/**************************************************************************/
+/*  openxr_android_unbounded_reference_space_extension.h                  */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <androidxr/androidxr.h>
+#include <godot_cpp/classes/open_xr_extension_wrapper.hpp>
+#include <map>
+
+#include "util.h"
+
+using namespace godot;
+
+class OpenXRAndroidUnboundedReferenceSpaceExtension : public OpenXRExtensionWrapper {
+	GDCLASS(OpenXRAndroidUnboundedReferenceSpaceExtension, OpenXRExtensionWrapper);
+
+public:
+	static OpenXRAndroidUnboundedReferenceSpaceExtension *get_singleton();
+
+	OpenXRAndroidUnboundedReferenceSpaceExtension();
+	~OpenXRAndroidUnboundedReferenceSpaceExtension();
+
+	godot::Dictionary _get_requested_extensions(uint64_t p_xr_version) override;
+
+	void _on_instance_created(uint64_t p_instance) override;
+	void _on_instance_destroyed() override;
+	void _on_session_created(uint64_t p_instance) override;
+
+	void set_unbounded_reference_space_enabled(bool p_enable);
+
+	bool is_unbounded_reference_space_available();
+
+	bool is_play_space_unbounded();
+
+protected:
+	static void _bind_methods();
+
+private:
+	EXT_PROTO_XRRESULT_FUNC3(xrCreateReferenceSpace,
+			(XrSession), session,
+			(const XrReferenceSpaceCreateInfo *), createInfo,
+			(XrSpace *), space)
+
+	EXT_PROTO_XRRESULT_FUNC1(xrDestroySpace,
+			(XrSpace), space)
+
+	bool initialize_androidxr_unbounded_reference_space_extension(XrInstance p_instance);
+
+	void cleanup();
+
+	static OpenXRAndroidUnboundedReferenceSpaceExtension *singleton;
+
+	std::map<godot::String, bool *> request_extensions;
+	bool androidxr_unbounded_reference_space_ext = false;
+
+	XrSpace unbounded_space = XR_NULL_HANDLE;
+};

--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -57,6 +57,7 @@
 #include "extensions/openxr_android_performance_metrics_extension.h"
 #include "extensions/openxr_android_recommended_resolution_extension.h"
 #include "extensions/openxr_android_scene_meshing_extension.h"
+#include "extensions/openxr_android_unbounded_reference_space_extension.h"
 #include "extensions/openxr_fb_android_surface_swapchain_create_extension.h"
 #include "extensions/openxr_fb_body_tracking_extension.h"
 #include "extensions/openxr_fb_color_space_extension.h"
@@ -178,6 +179,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			GDREGISTER_CLASS(OpenXRAndroidSceneMeshing);
 			GDREGISTER_CLASS(OpenXRAndroidSceneMeshingExtension);
 			GDREGISTER_CLASS(OpenXRAndroidSceneSubmeshData);
+			GDREGISTER_CLASS(OpenXRAndroidUnboundedReferenceSpaceExtension);
 
 			GDREGISTER_CLASS(OpenXRAndroidPassthroughCameraStateExtension);
 			GDREGISTER_CLASS(OpenXRAndroidPerformanceMetricsExtension);
@@ -369,6 +371,10 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			if (_get_bool_project_setting("xr/openxr/extensions/androidxr/environment_depth")) {
 				_register_extension_with_openxr(OpenXRAndroidEnvironmentDepthExtension::get_singleton());
 			}
+
+			if (_get_bool_project_setting("xr/openxr/extensions/androidxr/unbounded_reference_space")) {
+				_register_extension_with_openxr(OpenXRAndroidUnboundedReferenceSpaceExtension::get_singleton());
+			}
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_SERVERS:
@@ -402,6 +408,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			_register_extension_as_singleton(OpenXRFbSpaceWarpExtension::get_singleton());
 			_register_extension_as_singleton(OpenXRMetaEnvironmentDepthExtension::get_singleton());
 			_register_extension_as_singleton(OpenXRAndroidEnvironmentDepthExtension::get_singleton());
+			_register_extension_as_singleton(OpenXRAndroidUnboundedReferenceSpaceExtension::get_singleton());
 
 // @todo GH Issue 304: Remove check for meta headers when feature becomes part of OpenXR spec.
 #ifdef META_HEADERS_ENABLED
@@ -580,6 +587,8 @@ void add_plugin_project_settings() {
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/androidxr/dynamic_resolution", true);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/androidxr/scene_meshing", false);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/androidxr/environment_depth", false);
+	_add_bool_project_setting(project_settings, "xr/openxr/extensions/androidxr/unbounded_reference_space", false);
+	_add_bool_project_setting(project_settings, "xr/openxr/extensions/androidxr/unbounded_reference_space/enable_on_startup", false);
 
 // @todo GH Issue 304: Remove check for meta headers when feature becomes part of OpenXR spec.
 #ifdef META_HEADERS_ENABLED


### PR DESCRIPTION
This extension isn't currently a part of our AndroidXR headers or `openxr.h`, but appears to be implemented and works fine on my Galaxy XR headset. For implementation I've copied the def/enums `XR_ANDROID_UNBOUNDED_REFERENCE_SPACE_EXTENSION_NAME` and `XR_REFERENCE_SPACE_TYPE_UNBOUNDED_ANDROID` into `openxr_android_unbounded_reference_space_extension.h`. I figure that's fine and whenever these values are added via a proper header, these copied ones will just be deleted.