### PR TITLE
Implement XR_ANDROID_trackables_object

### DIFF
--- a/doc_classes/OpenXRAndroidTrackableObjectTracker.xml
+++ b/doc_classes/OpenXRAndroidTrackableObjectTracker.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRAndroidTrackableObjectTracker" inherits="OpenXRAndroidTrackableTracker" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		A tracker for an object (from [code]XR_ANDROID_trackables[/code]).
+	</brief_description>
+	<description>
+		A tracker for an object (from [code]XR_ANDROID_trackables[/code]).
+		See also [OpenXRAndroidTrackablesExtension].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_extents">
+			<return type="Vector3" />
+			<description>
+				Returns the width, height, and depth of the object, as [member Vector3.x], [member Vector3.y], and [member Vector3.z], respectively.
+				The width, height, and depth are centered on the pose from [method OpenXRAndroidTrackableTracker.get_center_pose].
+				For example, a width of [code]2[/code] means the object extends [code]1[/code] to the left and right of the center pose.
+			</description>
+		</method>
+		<method name="get_object_context">
+			<return type="RID" />
+			<description>
+				Get the [code]object context[/code] that was used to create this tracker.
+				See also [OpenXRAndroidTrackablesObjectExtension].
+			</description>
+		</method>
+		<method name="get_object_label">
+			<return type="int" enum="OpenXRAndroidTrackableObjectTracker.ObjectLabel" />
+			<description>
+				Return the [enum ObjectLabel] for this tracker.
+			</description>
+		</method>
+	</methods>
+	<constants>
+		<constant name="OBJECT_LABEL_UNKNOWN" value="0" enum="ObjectLabel">
+			The object is none of the other types.
+		</constant>
+		<constant name="OBJECT_LABEL_KEYBOARD" value="1" enum="ObjectLabel">
+			The object is a keyboard.
+		</constant>
+		<constant name="OBJECT_LABEL_MOUSE" value="2" enum="ObjectLabel">
+			The object is a computer mouse.
+		</constant>
+		<constant name="OBJECT_LABEL_LAPTOP" value="3" enum="ObjectLabel">
+			The object is a laptop.
+		</constant>
+	</constants>
+</class>

--- a/doc_classes/OpenXRAndroidTrackablesObjectExtension.xml
+++ b/doc_classes/OpenXRAndroidTrackablesObjectExtension.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRAndroidTrackablesObjectExtension" inherits="OpenXRExtensionWrapper" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Implementation for object trackables (from [code]XR_ANDROID_trackables_object[/code]).
+	</brief_description>
+	<description>
+		Implementation for object trackables (from [code]XR_ANDROID_trackables_object[/code]).
+		Depends on [OpenXRAndroidTrackablesExtension].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="create_object_context">
+			<return type="RID" />
+			<param index="0" name="object_labels" type="Array" />
+			<description>
+				Create a new context to be used in other methods in this class.
+				This is optional, unless if [method set_default_object_context_enabled] was called earlier with [code]false[/code].
+			</description>
+		</method>
+		<method name="discover_object_trackers">
+			<return type="void" />
+			<param index="0" name="update_trackers" type="bool" />
+			<param index="1" name="object_context" type="RID" default="RID()" />
+			<description>
+				Discover object trackers detected by the OpenXR runtime.
+				New object trackers since the last call to [method discover_object_trackers] are added to [XRServer].
+				Missing object trackers since the last call to [method discover_object_trackers] are removed from [XRServer].
+				If [param update_trackers] is [code]true[/code], all found trackers are updated.
+				If [param update_trackers] is [code]false[/code], all found trackers are not updated.  This is useful if you need to find new trackers/discard old trackers without updating all of them too.
+				If [param object_context] is valid, then only discover object trackers for that object context.
+				If [param object_context] is invalid, then discover all object trackers, including for all object contexts created by [method create_object_context].
+				This method does nothing if [method set_default_object_context_enabled] was called earlier with [code]false[/code], [param object_context] is [code]null[/code], and [method create_object_context] was not called or all contexts have been free'd by [method free_object_context].
+				This API is called automatically by default (see [method set_object_tracker_discovery_cooldown]).
+			</description>
+		</method>
+		<method name="free_object_context">
+			<return type="void" />
+			<param index="0" name="object_context" type="RID" />
+			<description>
+				Removes all object trackers that it found from [XRServer] and frees the object context created by [method create_object_context].
+			</description>
+		</method>
+		<method name="get_default_object_context">
+			<return type="RID" />
+			<description>
+				Get the default object context that is used to automatically discover objects with no additional setup.
+				Always returns an invalid [RID] if [method set_default_object_context_enabled] was previously called with [code]false[/code].
+			</description>
+		</method>
+		<method name="is_trackables_object_supported" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if object trackables is supported; otherwise [code]false[/code].
+			</description>
+		</method>
+		<method name="set_default_object_context_enabled">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				Set whether this extension should automatically use the default object context returned by [method get_default_object_context].
+				When [param enabled] is [code]true[/code], the default object context is created (if it's invalid) and used in the next call to [method discover_object_trackers].
+				When [param enabled] is [code]false[/code], the default object context is destroyed (if it's valid) by calling [method free_object_context] immediately.
+			</description>
+		</method>
+		<method name="set_object_tracker_discovery_cooldown">
+			<return type="void" />
+			<param index="0" name="cooldown" type="int" />
+			<description>
+				Set how many frames to wait before automatically calling [method discover_object_trackers].
+				When [param cooldown] is [code]0[/code], [method discover_object_trackers] is called every frame. Note that the XR runtime may not always have new data to retrieve.
+				When [param cooldown] is less than zero, [method discover_object_trackers] is no longer called automatically.  Your app can explicitly discover object trackers by calling [method discover_object_trackers].
+				Default is [code]60[/code].
+			</description>
+		</method>
+	</methods>
+</class>

--- a/docs/make_rst.py
+++ b/docs/make_rst.py
@@ -115,6 +115,7 @@ CORE_TYPES: List[str] = [
     "PackedVector2Array",
     "PackedVector3Array",
     "Projection",
+    "RID",
     "Rect2",
     "String",
     "StringName",

--- a/plugin/src/main/cpp/classes/openxr_android_trackable_object_tracker.cpp
+++ b/plugin/src/main/cpp/classes/openxr_android_trackable_object_tracker.cpp
@@ -1,0 +1,182 @@
+/**************************************************************************/
+/*  openxr_android_trackable_object_tracker.cpp                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "classes/openxr_android_trackable_object_tracker.h"
+
+#include <androidxr/androidxr.h>
+#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/core/error_macros.hpp>
+
+#include "extensions/openxr_android_trackables_object_extension.h"
+
+using namespace godot;
+
+OpenXRAndroidTrackableObjectTracker::OpenXRAndroidTrackableObjectTracker() {}
+OpenXRAndroidTrackableObjectTracker::~OpenXRAndroidTrackableObjectTracker() {}
+
+Ref<OpenXRAndroidTrackableTracker> OpenXRAndroidTrackableObjectTracker::create(XrTrackableANDROID p_trackable, XrTrackableTrackerANDROID p_trackable_tracker) {
+	Ref<OpenXRAndroidTrackableObjectTracker> ret{};
+	if (p_trackable == XR_NULL_TRACKABLE_ANDROID || p_trackable_tracker == XR_NULL_HANDLE) {
+		return ret;
+	}
+
+	ret.instantiate();
+	ret->_init(p_trackable, p_trackable_tracker, XR_TRACKABLE_TYPE_OBJECT_ANDROID);
+	ret->set_tracker_name(String("openxr/androidxr/trackable_object/") + String::num_uint64(OpenXRAndroidTrackablesObjectExtension::get_next_object_tracker_id()));
+	return ret;
+}
+
+Vector3 OpenXRAndroidTrackableObjectTracker::get_extents() {
+	_ensure_updated();
+	return extents;
+}
+
+OpenXRAndroidTrackableObjectTracker::ObjectLabel OpenXRAndroidTrackableObjectTracker::get_object_label() {
+	_ensure_updated();
+	return object_label;
+}
+
+RID OpenXRAndroidTrackableObjectTracker::get_object_context() {
+	ERR_FAIL_COND_V(get_xrtrackable_tracker() == XR_NULL_HANDLE, RID());
+
+	if (!object_context.is_valid()) {
+		OpenXRAndroidTrackablesObjectExtension *wrapper = OpenXRAndroidTrackablesObjectExtension::get_singleton();
+		ERR_FAIL_NULL_V(wrapper, RID());
+
+		object_context = wrapper->get_object_context(get_xrtrackable_tracker());
+
+		ERR_FAIL_COND_V_MSG(!object_context.is_valid(), RID(), "Failed to find a valid object context; how was this tracker created?");
+	}
+
+	return object_context;
+}
+
+void OpenXRAndroidTrackableObjectTracker::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_extents"), &OpenXRAndroidTrackableObjectTracker::get_extents);
+	ClassDB::bind_method(D_METHOD("get_object_label"), &OpenXRAndroidTrackableObjectTracker::get_object_label);
+	ClassDB::bind_method(D_METHOD("get_object_context"), &OpenXRAndroidTrackableObjectTracker::get_object_context);
+
+	BIND_ENUM_CONSTANT(OBJECT_LABEL_UNKNOWN);
+	BIND_ENUM_CONSTANT(OBJECT_LABEL_KEYBOARD);
+	BIND_ENUM_CONSTANT(OBJECT_LABEL_MOUSE);
+	BIND_ENUM_CONSTANT(OBJECT_LABEL_LAPTOP);
+}
+
+void OpenXRAndroidTrackableObjectTracker::_ensure_updated() {
+	// This function can be called multiple times per frame, however it will only do work once per
+	// frame
+	uint64_t frame = Engine::get_singleton()->get_process_frames();
+	if (last_frame == frame) {
+		return;
+	}
+	last_frame = frame;
+
+	// NOTE: unlike OpenXRAndroidTrackablePlaneTracker, we don't cache XrTrackableObjectANDROID
+	// because retrieving the info every time is not expensive (OpenXRAndroidTrackablePlaneTracker
+	// retrieves an array of vertices, which could be a lot of data)
+	XrTrackableObjectANDROID xr_trackable_object;
+	if (!_get_xrtrackable_info(xr_trackable_object)) {
+		_set_tracking_state(XR_TRACKING_STATE_STOPPED_ANDROID);
+		return;
+	}
+
+	// always set pose, even when old last updated time == xr_trackable_object.lastUpdatedTime, since
+	// it could have changed due to XR changing the reference space
+	extents.x = xr_trackable_object.extents.width;
+	extents.y = xr_trackable_object.extents.height;
+	extents.z = xr_trackable_object.extents.depth;
+	_set_center_pose(xr_trackable_object.centerPose);
+
+	if (_set_last_updated_time(xr_trackable_object.lastUpdatedTime) == xr_trackable_object.lastUpdatedTime) {
+		return;
+	}
+
+	switch (xr_trackable_object.objectLabel) {
+		case XR_OBJECT_LABEL_UNKNOWN_ANDROID:
+			object_label = OBJECT_LABEL_UNKNOWN;
+			break;
+		case XR_OBJECT_LABEL_KEYBOARD_ANDROID:
+			object_label = OBJECT_LABEL_KEYBOARD;
+			break;
+		case XR_OBJECT_LABEL_MOUSE_ANDROID:
+			object_label = OBJECT_LABEL_MOUSE;
+			break;
+		case XR_OBJECT_LABEL_LAPTOP_ANDROID:
+			object_label = OBJECT_LABEL_LAPTOP;
+			break;
+		case XR_OBJECT_LABEL_MAX_ENUM_ANDROID:
+		default:
+			UtilityFunctions::printerr("OpenXR: invalid object label: ", xr_trackable_object.objectLabel);
+			_set_tracking_state(XR_TRACKING_STATE_STOPPED_ANDROID);
+			return;
+	}
+
+	_set_tracking_state(xr_trackable_object.trackingState);
+
+	// Any recursive calls this 'updated' signal brings will early-return.
+	// It should never infinitely recurse.
+	emit_signal(StringName("updated"));
+}
+
+bool OpenXRAndroidTrackableObjectTracker::_get_xrtrackable_info(XrTrackableObjectANDROID &p_xr_trackable_object) {
+	ERR_FAIL_COND_V(get_xrtrackable() == XR_NULL_TRACKABLE_ANDROID, false);
+
+	OpenXRAndroidTrackablesObjectExtension *wrapper = OpenXRAndroidTrackablesObjectExtension::get_singleton();
+	ERR_FAIL_NULL_V(wrapper, false);
+
+	XrTrackableTrackerANDROID trackable_tracker = get_xrtrackable_tracker();
+	ERR_FAIL_COND_V(trackable_tracker == XR_NULL_HANDLE, false);
+
+	XrTrackableGetInfoANDROID get_info = {
+		XR_TYPE_TRACKABLE_GET_INFO_ANDROID, // type
+		nullptr, // next
+		get_xrtrackable(), // trackable
+		(XrSpace)wrapper->get_openxr_api()->get_play_space(), // baseSpace
+		(XrTime)wrapper->get_openxr_api()->get_predicted_display_time(), // time
+	};
+
+	p_xr_trackable_object = XrTrackableObjectANDROID{
+		XR_TYPE_TRACKABLE_OBJECT_ANDROID, // type
+		nullptr, // next
+		XR_TRACKING_STATE_PAUSED_ANDROID, // trackingState
+		{}, // centerPose
+		{}, // extents
+		XR_OBJECT_LABEL_UNKNOWN_ANDROID, // objectLabel
+		0, // lastUpdatedTime
+	};
+	XrResult result = wrapper->xrGetTrackableObjectANDROID(trackable_tracker, &get_info, &p_xr_trackable_object);
+	if (result != XR_SUCCESS) {
+		UtilityFunctions::printerr("OpenXR: Failed to get trackable object; ", wrapper->get_openxr_api()->get_error_string(result));
+		return false;
+	}
+
+	return true;
+}

--- a/plugin/src/main/cpp/extensions/openxr_android_trackables_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_trackables_extension.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "extensions/openxr_android_trackables_extension.h"
+#include "classes/openxr_android_trackable_object_tracker.h"
 #include "classes/openxr_android_trackable_plane_tracker.h"
 #include "godot_cpp/classes/xr_server.hpp"
 
@@ -562,6 +563,9 @@ Ref<OpenXRAndroidTrackableTracker> OpenXRAndroidTrackablesExtension::_get_or_cre
 		switch ((int)p_xrtrackable_type) {
 			case XR_TRACKABLE_TYPE_PLANE_ANDROID:
 				ret = OpenXRAndroidTrackablePlaneTracker::create(p_xrtrackable, p_xrtrackable_tracker);
+				break;
+			case XR_TRACKABLE_TYPE_OBJECT_ANDROID:
+				ret = OpenXRAndroidTrackableObjectTracker::create(p_xrtrackable, p_xrtrackable_tracker);
 				break;
 			default:
 				UtilityFunctions::printerr("OpenXR: Unsupported trackable type; ", p_xrtrackable_type);

--- a/plugin/src/main/cpp/extensions/openxr_android_trackables_object_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_trackables_object_extension.cpp
@@ -1,0 +1,299 @@
+/**************************************************************************/
+/*  openxr_android_trackables_object_extension.cpp                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "extensions/openxr_android_trackables_object_extension.h"
+#include "classes/openxr_android_trackable_object_tracker.h"
+#include "extensions/openxr_android_trackables_extension.h"
+
+#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/core/error_macros.hpp>
+#include <godot_cpp/core/memory.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+OpenXRAndroidTrackablesObjectExtension *OpenXRAndroidTrackablesObjectExtension::singleton = nullptr;
+
+OpenXRAndroidTrackablesObjectExtension *OpenXRAndroidTrackablesObjectExtension::get_singleton() {
+	if (singleton == nullptr) {
+		memnew(OpenXRAndroidTrackablesObjectExtension());
+	}
+	return singleton;
+}
+
+int OpenXRAndroidTrackablesObjectExtension::get_next_object_tracker_id() {
+	OpenXRAndroidTrackablesObjectExtension *wrapper = OpenXRAndroidTrackablesObjectExtension::get_singleton();
+	ERR_FAIL_NULL_V(wrapper, -1);
+
+	int ret = wrapper->next_object_tracker_id;
+	++wrapper->next_object_tracker_id;
+
+	return ret;
+}
+
+OpenXRAndroidTrackablesObjectExtension::OpenXRAndroidTrackablesObjectExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRAndroidTrackablesObjectExtension singleton already exists.");
+
+	singleton = this;
+	request_extensions[XR_ANDROID_TRACKABLES_OBJECT_EXTENSION_NAME] = &available;
+}
+
+OpenXRAndroidTrackablesObjectExtension::~OpenXRAndroidTrackablesObjectExtension() {
+	singleton = nullptr;
+}
+
+Dictionary OpenXRAndroidTrackablesObjectExtension::_get_requested_extensions(uint64_t p_xr_version) {
+	Dictionary result;
+	for (auto ext : request_extensions) {
+		uint64_t value = reinterpret_cast<uint64_t>(ext.value);
+		result[ext.key] = (Variant)value;
+	}
+	return result;
+}
+
+void OpenXRAndroidTrackablesObjectExtension::_on_instance_created(uint64_t p_instance) {
+	if (!available) {
+		return;
+	}
+
+	if (!_initialize_openxr_android_trackables_object_extension()) {
+		UtilityFunctions::print("Failed to initialize trackables extension");
+		available = false;
+		return;
+	}
+
+	// assume unavailable until the permission is granted (see _on_state_focused())
+	available = false;
+	check_for_permissions = true;
+}
+
+void OpenXRAndroidTrackablesObjectExtension::_on_state_focused() {
+	if (!available && !check_for_permissions) {
+		return;
+	}
+
+	// always check for permissions for every focused event, since this is possible:
+	// 1: the app launched, but required permissions are not available
+	// 2: the user opens Android settings app and enables the permission (pauses this app)
+	// 3: the user switches back to this app (resumes and focuses this app)
+	//
+	// NOTE: the MainLoop's "on_request_permissions_result" signal is not always called (including for
+	//       "adb shell pm grant the.app.package android.permission.SCENE_UNDERSTANDING_COARSE"),
+	//       which is why we are always checking here.
+	// NOTE: depending on the app's manifest, it may be restarted if permissions are removed or
+	//       enabled
+
+	// assume unavailable until the permission is granted
+	available = false;
+
+	OS *os = OS::get_singleton();
+	ERR_FAIL_NULL(os);
+
+	PackedStringArray granted_permissions = os->get_granted_permissions();
+	available = granted_permissions.has("android.permission.SCENE_UNDERSTANDING_COARSE") || granted_permissions.has("android.permission.SCENE_UNDERSTANDING_FINE");
+
+	if (!available) {
+		WARN_PRINT("OpenXR: XR_ANDROID_trackables_object requires android.permission.SCENE_UNDERSTANDING_COARSE or android.permission.SCENE_UNDERSTANDING_FINE; waiting for one of them to be granted before enabling");
+	}
+}
+
+void OpenXRAndroidTrackablesObjectExtension::_on_process() {
+	if (!available || object_trackable_discovery_cooldown < 0) {
+		return;
+	}
+
+	if (0 < object_trackable_discovery_cooldown_cur) {
+		--object_trackable_discovery_cooldown_cur;
+		return;
+	}
+	object_trackable_discovery_cooldown_cur = object_trackable_discovery_cooldown;
+
+	discover_object_trackers(true);
+}
+
+void OpenXRAndroidTrackablesObjectExtension::_on_session_destroyed() {
+	OpenXRAndroidTrackablesExtension *wrapper = OpenXRAndroidTrackablesExtension::get_singleton();
+	ERR_FAIL_NULL(wrapper);
+
+	if (default_object_context.is_valid()) {
+		free_object_context(default_object_context);
+		default_object_context = RID();
+	}
+
+	List<RID> object_context_rids;
+	object_context_owner.get_owned_list(&object_context_rids);
+	for (const RID &object_context_rid : object_context_rids) {
+		free_object_context(object_context_rid);
+	}
+}
+
+bool OpenXRAndroidTrackablesObjectExtension::is_trackables_object_supported() const {
+	return available;
+}
+
+void OpenXRAndroidTrackablesObjectExtension::set_default_object_context_enabled(bool p_enabled) {
+	if (default_object_context_enabled == p_enabled) {
+		return;
+	}
+
+	default_object_context_enabled = p_enabled;
+	if (!default_object_context_enabled) {
+		free_object_context(default_object_context);
+		default_object_context = RID();
+	}
+}
+
+void OpenXRAndroidTrackablesObjectExtension::set_object_tracker_discovery_cooldown(int p_cooldown) {
+	object_trackable_discovery_cooldown = p_cooldown;
+	object_trackable_discovery_cooldown_cur = p_cooldown;
+}
+
+void OpenXRAndroidTrackablesObjectExtension::discover_object_trackers(bool p_update_trackers, RID p_object_context) {
+	OpenXRAndroidTrackablesExtension *wrapper = OpenXRAndroidTrackablesExtension::get_singleton();
+	ERR_FAIL_NULL(wrapper);
+
+	ObjectContext *object_context = object_context_owner.get_or_null(p_object_context);
+	if (object_context == nullptr) {
+		// ensure the default object context is created
+		get_default_object_context();
+
+		// update every object context (which includes the default object context)
+		List<RID> object_context_rids;
+		object_context_owner.get_owned_list(&object_context_rids);
+		for (const RID &object_context_rid : object_context_rids) {
+			object_context = object_context_owner.get_or_null(object_context_rid);
+			wrapper->find_and_update_all_trackers(object_context->xrtrackable_tracker, XR_TRACKABLE_TYPE_OBJECT_ANDROID, p_update_trackers, object_context->xrtrackable_to_tracker);
+		}
+	} else {
+		wrapper->find_and_update_all_trackers(object_context->xrtrackable_tracker, XR_TRACKABLE_TYPE_OBJECT_ANDROID, p_update_trackers, object_context->xrtrackable_to_tracker);
+	}
+}
+
+RID OpenXRAndroidTrackablesObjectExtension::get_default_object_context() {
+	OpenXRAndroidTrackablesExtension *wrapper = OpenXRAndroidTrackablesExtension::get_singleton();
+	ERR_FAIL_NULL_V(wrapper, RID());
+
+	if (default_object_context_enabled && !default_object_context.is_valid()) {
+		XrTrackableTrackerANDROID xrtrackable_tracker = wrapper->get_or_create_xrtrackable_tracker(XR_TRACKABLE_TYPE_OBJECT_ANDROID, XR_NULL_HANDLE, nullptr);
+		default_object_context = _make_object_context(xrtrackable_tracker);
+	}
+
+	return default_object_context;
+}
+
+RID OpenXRAndroidTrackablesObjectExtension::create_object_context(Array p_object_labels) {
+	LocalVector<XrObjectLabelANDROID> active_labels;
+	for (int i = 0; i < p_object_labels.size(); ++i) {
+		switch ((int)p_object_labels[i]) {
+			case OpenXRAndroidTrackableObjectTracker::OBJECT_LABEL_UNKNOWN:
+				active_labels.push_back(XR_OBJECT_LABEL_UNKNOWN_ANDROID);
+				break;
+			case OpenXRAndroidTrackableObjectTracker::OBJECT_LABEL_KEYBOARD:
+				active_labels.push_back(XR_OBJECT_LABEL_KEYBOARD_ANDROID);
+				break;
+			case OpenXRAndroidTrackableObjectTracker::OBJECT_LABEL_MOUSE:
+				active_labels.push_back(XR_OBJECT_LABEL_MOUSE_ANDROID);
+				break;
+			case OpenXRAndroidTrackableObjectTracker::OBJECT_LABEL_LAPTOP:
+				active_labels.push_back(XR_OBJECT_LABEL_LAPTOP_ANDROID);
+				break;
+			default:
+				WARN_PRINT(vformat("Got an unexpected object label: %d", p_object_labels[i]));
+				break;
+		}
+	}
+
+	ERR_FAIL_COND_V_MSG(active_labels.is_empty(), RID(), "At least one object label must be provided.");
+
+	OpenXRAndroidTrackablesExtension *wrapper = OpenXRAndroidTrackablesExtension::get_singleton();
+	ERR_FAIL_NULL_V(wrapper, RID());
+
+	XrTrackableObjectConfigurationANDROID object_configuration{
+		XR_TYPE_TRACKABLE_OBJECT_CONFIGURATION_ANDROID, // type
+		nullptr, // next
+		active_labels.size(), // labelCount
+		active_labels.ptr() // activeLabels
+	};
+	XrTrackableTrackerANDROID xrtrackable_tracker = wrapper->get_or_create_xrtrackable_tracker(XR_TRACKABLE_TYPE_OBJECT_ANDROID, XR_NULL_HANDLE, &object_configuration);
+	return _make_object_context(xrtrackable_tracker);
+}
+
+RID OpenXRAndroidTrackablesObjectExtension::get_object_context(XrTrackableTrackerANDROID p_xrtrackable_tracker) {
+	List<RID> object_context_rids;
+	object_context_owner.get_owned_list(&object_context_rids);
+	for (const RID &object_context_rid : object_context_rids) {
+		ObjectContext *object_context = object_context_owner.get_or_null(object_context_rid);
+		if (object_context != nullptr && object_context->xrtrackable_tracker == p_xrtrackable_tracker) {
+			return object_context_rid;
+		}
+	}
+
+	return RID();
+}
+
+void OpenXRAndroidTrackablesObjectExtension::free_object_context(RID p_object_context) {
+	ObjectContext *object_context = object_context_owner.get_or_null(p_object_context);
+	if (object_context == nullptr) {
+		return;
+	}
+
+	OpenXRAndroidTrackablesExtension *wrapper = OpenXRAndroidTrackablesExtension::get_singleton();
+	ERR_FAIL_NULL(wrapper);
+
+	wrapper->maybe_destroy_trackable_tracker(object_context->xrtrackable_tracker, object_context->xrtrackable_to_tracker);
+	object_context_owner.free(p_object_context);
+}
+
+void OpenXRAndroidTrackablesObjectExtension::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_trackables_object_supported"), &OpenXRAndroidTrackablesObjectExtension::is_trackables_object_supported);
+	ClassDB::bind_method(D_METHOD("set_default_object_context_enabled", "enabled"), &OpenXRAndroidTrackablesObjectExtension::set_default_object_context_enabled);
+	ClassDB::bind_method(D_METHOD("set_object_tracker_discovery_cooldown", "cooldown"), &OpenXRAndroidTrackablesObjectExtension::set_object_tracker_discovery_cooldown);
+	ClassDB::bind_method(D_METHOD("discover_object_trackers", "update_trackers", "object_context"), &OpenXRAndroidTrackablesObjectExtension::discover_object_trackers, DEFVAL(RID()));
+	ClassDB::bind_method(D_METHOD("get_default_object_context"), &OpenXRAndroidTrackablesObjectExtension::get_default_object_context);
+	ClassDB::bind_method(D_METHOD("create_object_context", "object_labels"), &OpenXRAndroidTrackablesObjectExtension::create_object_context);
+	ClassDB::bind_method(D_METHOD("free_object_context", "object_context"), &OpenXRAndroidTrackablesObjectExtension::free_object_context);
+}
+
+bool OpenXRAndroidTrackablesObjectExtension::_initialize_openxr_android_trackables_object_extension() {
+	GDEXTENSION_INIT_XR_FUNC_V(xrGetTrackableObjectANDROID);
+	return true;
+}
+
+RID OpenXRAndroidTrackablesObjectExtension::_make_object_context(XrTrackableTrackerANDROID p_xrtrackable_tracker) {
+	ObjectContext object_context = {
+		p_xrtrackable_tracker, // xrtrackable_tracker
+		{}, // xrtrackable_to_tracker
+	};
+	return object_context_owner.make_rid(object_context);
+}

--- a/plugin/src/main/cpp/include/classes/openxr_android_trackable_object_tracker.h
+++ b/plugin/src/main/cpp/include/classes/openxr_android_trackable_object_tracker.h
@@ -1,0 +1,73 @@
+/**************************************************************************/
+/*  openxr_android_trackable_object_tracker.h                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <androidxr/androidxr.h>
+
+#include "classes/openxr_android_trackable_tracker.h"
+
+using namespace godot;
+
+class OpenXRAndroidTrackableObjectTracker : public OpenXRAndroidTrackableTracker {
+	GDCLASS(OpenXRAndroidTrackableObjectTracker, OpenXRAndroidTrackableTracker);
+
+public:
+	OpenXRAndroidTrackableObjectTracker();
+	virtual ~OpenXRAndroidTrackableObjectTracker() override;
+
+	enum ObjectLabel {
+		OBJECT_LABEL_UNKNOWN,
+		OBJECT_LABEL_KEYBOARD,
+		OBJECT_LABEL_MOUSE,
+		OBJECT_LABEL_LAPTOP,
+	};
+
+	static Ref<OpenXRAndroidTrackableTracker> create(XrTrackableANDROID p_trackable, XrTrackableTrackerANDROID p_trackable_tracker);
+
+	Vector3 get_extents();
+	ObjectLabel get_object_label();
+	RID get_object_context();
+
+protected:
+	static void _bind_methods();
+
+private:
+	void _ensure_updated() override;
+	bool _get_xrtrackable_info(XrTrackableObjectANDROID &p_xr_trackable_object);
+
+	uint64_t last_frame = -1;
+
+	Vector3 extents;
+	ObjectLabel object_label = OBJECT_LABEL_UNKNOWN;
+	RID object_context;
+};
+
+VARIANT_ENUM_CAST(OpenXRAndroidTrackableObjectTracker::ObjectLabel);

--- a/plugin/src/main/cpp/include/extensions/openxr_android_trackables_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_android_trackables_extension.h
@@ -118,6 +118,16 @@ private:
 	LocalVector<XrTrackableTypeANDROID> supported_trackable_types;
 
 	// Plane trackables
+	// NOTE: unlike OpenXRAndroidTrackablesObjectExtension, we do not have an API for a user to create
+	// separate plane-contexts (XrTrackableTrackerANDROID), because there is less use for
+	// it.  OpenXRAndroidTrackablesObjectExtension is capable of creating different
+	// XrTrackableTrackerANDROIDs that filter object types (like, only find "keyboard", instead of
+	// everything), unlike planes where each context is essentially identical.  Additionally,
+	// XrRaycastHitResultANDROID doesn't specify which XrTrackableTrackerANDROID the hit result is
+	// for, which would force us to search every plane-context to find a matching XrTrackableANDROID.
+	// If we do decide to add it, use OpenXRAndroidTrackablesObjectExtension as an example of which
+	// APIs and members to add, and for raycasts we'll have to search all plane-contexts to find the
+	// matching XrTrackableANDROID
 	HashMap<XrTrackableANDROID, Ref<OpenXRAndroidTrackableTracker>> current_plane_trackables;
 	XrTrackableTrackerANDROID plane_trackable_tracker = XR_NULL_HANDLE;
 	int next_plane_tracker_id = 1;
@@ -125,7 +135,8 @@ private:
 	int plane_trackable_discovery_cooldown_cur = 0;
 
 	// Anchors
-	// Unlike Plane trackables, there is no XrTrackableTrackerANDROID, meaning no separate contexts
+	// Unlike trackables (Plane and Object), there is no XrTrackableTrackerANDROID, meaning no
+	// separate contexts
 	LocalVector<XrTrackableTypeANDROID> supported_anchor_trackable_types;
 	HashMap<XrSpace, Ref<OpenXRAndroidAnchorTracker>> current_anchor_trackers;
 	int next_anchor_tracker_id = 1;

--- a/plugin/src/main/cpp/include/extensions/openxr_android_trackables_object_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_android_trackables_object_extension.h
@@ -1,0 +1,97 @@
+/**************************************************************************/
+/*  openxr_android_trackables_object_extension.h                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <androidxr/androidxr.h>
+#include <godot_cpp/classes/open_xr_extension_wrapper.hpp>
+#include <godot_cpp/templates/hash_map.hpp>
+#include <godot_cpp/templates/rid_owner.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+#include "classes/openxr_android_trackable_tracker.h"
+#include "util.h"
+
+using namespace godot;
+
+class OpenXRAndroidTrackablesObjectExtension : public OpenXRExtensionWrapper {
+	GDCLASS(OpenXRAndroidTrackablesObjectExtension, OpenXRExtensionWrapper);
+
+public:
+	static OpenXRAndroidTrackablesObjectExtension *get_singleton();
+	static int get_next_object_tracker_id();
+
+	OpenXRAndroidTrackablesObjectExtension();
+	virtual ~OpenXRAndroidTrackablesObjectExtension() override;
+
+	virtual Dictionary _get_requested_extensions(uint64_t p_xr_version) override;
+	virtual void _on_instance_created(uint64_t p_instance) override;
+	virtual void _on_state_focused() override;
+	virtual void _on_process() override;
+	virtual void _on_session_destroyed() override;
+
+	bool is_trackables_object_supported() const;
+	void set_default_object_context_enabled(bool p_enabled);
+	void set_object_tracker_discovery_cooldown(int p_cooldown);
+	void discover_object_trackers(bool p_update_trackers, RID p_object_context = RID());
+	RID get_default_object_context();
+	RID create_object_context(Array p_object_labels);
+	RID get_object_context(XrTrackableTrackerANDROID p_xrtrackable_tracker);
+	void free_object_context(RID p_object_context);
+
+	EXT_PROTO_XRRESULT_FUNC3(xrGetTrackableObjectANDROID, (XrTrackableTrackerANDROID), trackableTracker, (const XrTrackableGetInfoANDROID *), getInfo, (XrTrackableObjectANDROID *), objectOutput);
+
+protected:
+	static void _bind_methods();
+
+private:
+	static OpenXRAndroidTrackablesObjectExtension *singleton;
+
+	bool _initialize_openxr_android_trackables_object_extension();
+	void _on_request_permissions_result(const String &p_permission, bool p_granted);
+	RID _make_object_context(XrTrackableTrackerANDROID p_xrtrackable_tracker);
+
+	HashMap<String, bool *> request_extensions;
+	bool available = false;
+	bool check_for_permissions = false;
+
+	int object_trackable_discovery_cooldown = 60;
+	int object_trackable_discovery_cooldown_cur = 0;
+	bool default_object_context_enabled = true;
+	RID default_object_context;
+
+	struct ObjectContext {
+		XrTrackableTrackerANDROID xrtrackable_tracker;
+		HashMap<XrTrackableANDROID, Ref<OpenXRAndroidTrackableTracker>> xrtrackable_to_tracker;
+	};
+	RID_Owner<ObjectContext> object_context_owner;
+
+	int next_object_tracker_id = 1;
+};

--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -59,6 +59,7 @@
 #include "extensions/openxr_android_recommended_resolution_extension.h"
 #include "extensions/openxr_android_scene_meshing_extension.h"
 #include "extensions/openxr_android_trackables_extension.h"
+#include "extensions/openxr_android_trackables_object_extension.h"
 #include "extensions/openxr_android_unbounded_reference_space_extension.h"
 #include "extensions/openxr_fb_android_surface_swapchain_create_extension.h"
 #include "extensions/openxr_fb_body_tracking_extension.h"
@@ -101,6 +102,7 @@
 #include "classes/openxr_android_environment_depth.h"
 #include "classes/openxr_android_light_estimation.h"
 #include "classes/openxr_android_scene_submesh_data.h"
+#include "classes/openxr_android_trackable_object_tracker.h"
 #include "classes/openxr_android_trackable_plane_tracker.h"
 #include "classes/openxr_fb_hand_tracking_mesh.h"
 #include "classes/openxr_fb_passthrough_geometry.h"
@@ -187,6 +189,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			GDREGISTER_CLASS(OpenXRAndroidUnboundedReferenceSpaceExtension);
 
 			GDREGISTER_CLASS(OpenXRAndroidTrackablesExtension);
+			GDREGISTER_CLASS(OpenXRAndroidTrackablesObjectExtension);
 
 			GDREGISTER_CLASS(OpenXRAndroidPassthroughCameraStateExtension);
 			GDREGISTER_CLASS(OpenXRAndroidPerformanceMetricsExtension);
@@ -395,6 +398,10 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			if (_get_bool_project_setting("xr/openxr/extensions/androidxr/trackables")) {
 				_register_extension_with_openxr(OpenXRAndroidTrackablesExtension::get_singleton());
 			}
+
+			if (_get_bool_project_setting("xr/openxr/extensions/androidxr/trackables_object")) {
+				_register_extension_with_openxr(OpenXRAndroidTrackablesObjectExtension::get_singleton());
+			}
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_SERVERS:
@@ -450,6 +457,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			GDREGISTER_CLASS(OpenXRAndroidLightEstimation);
 
 			GDREGISTER_ABSTRACT_CLASS(OpenXRAndroidTrackableTracker);
+			GDREGISTER_CLASS(OpenXRAndroidTrackableObjectTracker);
 			GDREGISTER_CLASS(OpenXRAndroidTrackablePlaneTracker);
 			GDREGISTER_CLASS(OpenXRAndroidAnchorTracker);
 
@@ -625,6 +633,7 @@ void add_plugin_project_settings() {
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/androidxr/unbounded_reference_space", false);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/androidxr/unbounded_reference_space/enable_on_startup", false);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/androidxr/trackables", false);
+	_add_bool_project_setting(project_settings, "xr/openxr/extensions/androidxr/trackables_object", false);
 
 	// Only works with Godot 4.7 or later.
 	if (godot::gdextension_interface::godot_version.minor >= 7) {

--- a/samples/androidxr-trackables-sample/main.tscn
+++ b/samples/androidxr-trackables-sample/main.tscn
@@ -1,6 +1,7 @@
 [gd_scene format=3 uid="uid://hlh0gnwobk0v"]
 
 [ext_resource type="Script" uid="uid://bxtaynhowwmw3" path="res://main.gd" id="1_h2yge"]
+[ext_resource type="PackedScene" uid="uid://cj2x0p2apw5yn" path="res://objects/objects.tscn" id="5_5vw27"]
 [ext_resource type="PackedScene" uid="uid://38dsaj45w8yt" path="res://planes/planes.tscn" id="5_272bh"]
 
 [node name="Main" type="Node3D" unique_id=328323955]
@@ -11,3 +12,5 @@ script = ExtResource("1_h2yge")
 [node name="XRCamera3D" type="XRCamera3D" parent="XROrigin3D" unique_id=1005972866]
 
 [node name="Planes" parent="XROrigin3D" unique_id=213923288 instance=ExtResource("5_272bh")]
+
+[node name="Objects" parent="XROrigin3D" unique_id=329444580 instance=ExtResource("5_5vw27")]

--- a/samples/androidxr-trackables-sample/objects/object_trackable_visual/object_trackable_visual.gd
+++ b/samples/androidxr-trackables-sample/objects/object_trackable_visual/object_trackable_visual.gd
@@ -1,0 +1,64 @@
+extends XRAnchor3D
+
+var _object_tracker: OpenXRAndroidTrackableObjectTracker
+var _label: Label3D
+var _extents: MeshInstance3D
+
+
+# manually billboard the label since the billboard flags don't look quite right
+func _process(delta: float) -> void:
+	_label.look_at(get_tree().root.get_camera_3d().get_camera_transform().origin, Vector3.UP, true)
+
+
+func set_object_tracker(new_object_tracker: OpenXRAndroidTrackableObjectTracker):
+	# currently only handle one object tracker
+	if _object_tracker:
+		push_error("Expect exactly one call to each set_object_tracker; why was this called twice?")
+		return
+
+	_object_tracker = new_object_tracker
+	_label = $Label3D
+	_extents = $Extents
+
+	# Set this XRAnchor3D's tracker to the XRTracker's name to receive automatic pose updates
+	# (the XRTracker updates the "default" pose, which happens to be our default pose name too)
+	tracker = _object_tracker.get_tracker_name()
+
+	match _object_tracker.get_object_label():
+		OpenXRAndroidTrackableObjectTracker.OBJECT_LABEL_UNKNOWN:
+			_label.text = "OBJECT_LABEL_UNKNOWN\n"
+		OpenXRAndroidTrackableObjectTracker.OBJECT_LABEL_KEYBOARD:
+			_label.text = "OBJECT_LABEL_KEYBOARD\n"
+		OpenXRAndroidTrackableObjectTracker.OBJECT_LABEL_MOUSE:
+			_label.text = "OBJECT_LABEL_MOUSE\n"
+		OpenXRAndroidTrackableObjectTracker.OBJECT_LABEL_LAPTOP:
+			_label.text = "OBJECT_LABEL_LAPTOP\n"
+		_:
+			_label.text = "(bad object label)\n"
+
+	new_object_tracker.updated.connect(_update)
+	_update()
+
+
+func _update():
+	_extents.mesh.size = _object_tracker.get_extents()
+
+	# keep the object label string since it never changes. Discard everything else
+	var object_label_str: String = _label.text.split("\n", false, 1)[0] + "\n"
+
+	match _object_tracker.get_tracking_state():
+		OpenXRAndroidTrackableTracker.TRACKING_STATE_PAUSED:
+			object_label_str += "TRACKING_STATE_PAUSED\n"
+		OpenXRAndroidTrackableTracker.TRACKING_STATE_STOPPED:
+			object_label_str += "TRACKING_STATE_STOPPED\n"
+		OpenXRAndroidTrackableTracker.TRACKING_STATE_TRACKING:
+			object_label_str += "TRACKING_STATE_TRACKING\n"
+		OpenXRAndroidTrackableTracker.TRACKING_STATE_UNKNOWN:
+			object_label_str += "TRACKING_STATE_UNKNOWN\n"
+		_:
+			object_label_str += "(bad tracking state)\n"
+
+	object_label_str += "Extents: " + str(_object_tracker.get_extents()) + "\n"
+	object_label_str += "Position: " + str(_object_tracker.get_center_pose().origin)
+
+	_label.text = object_label_str

--- a/samples/androidxr-trackables-sample/objects/object_trackable_visual/object_trackable_visual.gd.uid
+++ b/samples/androidxr-trackables-sample/objects/object_trackable_visual/object_trackable_visual.gd.uid
@@ -1,0 +1,1 @@
+uid://cdbuwikjrwpqt

--- a/samples/androidxr-trackables-sample/objects/object_trackable_visual/object_trackable_visual.tscn
+++ b/samples/androidxr-trackables-sample/objects/object_trackable_visual/object_trackable_visual.tscn
@@ -1,0 +1,26 @@
+[gd_scene format=3 uid="uid://bnv1lg4ymtjmp"]
+
+[ext_resource type="Script" uid="uid://cdbuwikjrwpqt" path="res://objects/object_trackable_visual/object_trackable_visual.gd" id="1_qffip"]
+[ext_resource type="PackedScene" uid="uid://lq524cbr72ox" path="res://addons/common/axis3d/axis3d.tscn" id="2_hdvsy"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_6xxru"]
+transparency = 1
+shading_mode = 0
+albedo_color = Color(1, 1, 1, 0.33333334)
+
+[sub_resource type="BoxMesh" id="BoxMesh_yvhtj"]
+resource_local_to_scene = true
+material = SubResource("StandardMaterial3D_6xxru")
+
+[node name="ObjectTrackableVisual" type="XRAnchor3D" unique_id=1402453999]
+script = ExtResource("1_qffip")
+
+[node name="Axis3D" parent="." unique_id=1052878927 instance=ExtResource("2_hdvsy")]
+
+[node name="Label3D" type="Label3D" parent="." unique_id=237342640]
+pixel_size = 0.0003
+double_sided = false
+no_depth_test = true
+
+[node name="Extents" type="MeshInstance3D" parent="." unique_id=281849758]
+mesh = SubResource("BoxMesh_yvhtj")

--- a/samples/androidxr-trackables-sample/objects/objects.gd
+++ b/samples/androidxr-trackables-sample/objects/objects.gd
@@ -1,0 +1,40 @@
+extends Node3D
+
+const OBJECT_TRACKABLE_VISUAL = preload("res://objects/object_trackable_visual/object_trackable_visual.tscn")
+
+var _visuals_dict: Dictionary
+
+
+func _ready():
+	XRServer.tracker_added.connect(_on_tracker_added)
+	XRServer.tracker_removed.connect(_on_tracker_removed)
+
+
+func _on_tracker_added(tracker_name: StringName, _type: int):
+	var tracker: XRTracker = XRServer.get_tracker(tracker_name)
+
+	if not tracker:
+		push_error("Couldn't retrieve tracker!")
+		return
+
+	var trackable_visual: XRAnchor3D
+	if tracker is OpenXRAndroidTrackableObjectTracker:
+		trackable_visual = OBJECT_TRACKABLE_VISUAL.instantiate()
+		trackable_visual.set_object_tracker(tracker)
+	else:
+		return
+
+	add_child(trackable_visual)
+	_visuals_dict[tracker_name] = trackable_visual
+
+
+func _on_tracker_removed(tracker_name: StringName, _type: int):
+	_on_tracker_removed_impl(tracker_name)
+
+
+func _on_tracker_removed_impl(tracker_name: StringName):
+	if !_visuals_dict.has(tracker_name):
+		return
+
+	_visuals_dict[tracker_name].queue_free()
+	_visuals_dict.erase(tracker_name)

--- a/samples/androidxr-trackables-sample/objects/objects.gd.uid
+++ b/samples/androidxr-trackables-sample/objects/objects.gd.uid
@@ -1,0 +1,1 @@
+uid://beaj3v546iu0f

--- a/samples/androidxr-trackables-sample/objects/objects.tscn
+++ b/samples/androidxr-trackables-sample/objects/objects.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3 uid="uid://cj2x0p2apw5yn"]
+
+[ext_resource type="Script" uid="uid://beaj3v546iu0f" path="res://objects/objects.gd" id="1_o5n7m"]
+
+[node name="Objects" type="Node3D" unique_id=213923288]
+script = ExtResource("1_o5n7m")

--- a/samples/androidxr-trackables-sample/project.godot
+++ b/samples/androidxr-trackables-sample/project.godot
@@ -35,3 +35,4 @@ openxr/environment_blend_mode=2
 openxr/extensions/hand_interaction_profile=true
 shaders/enabled=true
 openxr/extensions/androidxr/trackables=true
+openxr/extensions/androidxr/trackables_object=true


### PR DESCRIPTION
Implements [XR_ANDROID_trackables_object](https://registry.khronos.org/OpenXR/specs/1.1/html/xrspec.html#XR_ANDROID_trackables_object)
Rebased on https://github.com/GodotVR/godot_openxr_vendors/pull/455