### PR TITLE
Fix unresolved references to enums on core classes

### DIFF
--- a/docs/make_rst.py
+++ b/docs/make_rst.py
@@ -1322,6 +1322,8 @@ def make_enum(t: str, state: State) -> str:
 
     if '.' in t:
         (c, e) = t.rsplit('.', 1)
+        if c in CORE_TYPES:
+            return t
     else:
         c = state.current_class
         e = t


### PR DESCRIPTION
In our `make_rst.py`, we don't attempt to resolve any references on core types, because we only have all the data for classes defined in this extension.

We already have code to avoid trying to resolve global core enums, but not enums on core classes.

This PR fixes that!