### PR TITLE
Bump version and update `CHANGES.md` for 5.0.0-stable release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 5.0.0
 
+- Do not initialize light estimation extension if unsupported (#478)
+- Fix some minor issues identified by AI (#476)
 - Change space warp sample to use OpenGL renderer (#472)
 - Remove the "Simple Controller" interaction profile in all samples (#471)
 - Add support for `XR_ANDROID_unbounded_reference_space` extension (#458)

--- a/config.gradle
+++ b/config.gradle
@@ -23,7 +23,7 @@ ext {
 
     // Parse the release version from the gradle project properties (e.g: -Prelease_version=<version>)
     getReleaseVersion = { ->
-        final String defaultVersion = "5.0.0-rc1" // Also update 'plugin/src/main/cpp/include/export/export_plugin.h#PLUGIN_VERSION'
+        final String defaultVersion = "5.0.0-stable" // Also update 'plugin/src/main/cpp/include/export/export_plugin.h#PLUGIN_VERSION'
 
         String releaseVersion = project.hasProperty("release_version") ? project.property("release_version") : defaultVersion
         if (releaseVersion == null || releaseVersion.isEmpty()) {

--- a/plugin/src/main/cpp/include/export/export_plugin.h
+++ b/plugin/src/main/cpp/include/export/export_plugin.h
@@ -40,7 +40,7 @@
 
 using namespace godot;
 
-static const char *PLUGIN_VERSION = "5.0.0-rc1"; // Also update 'config.gradle#defaultVersion'
+static const char *PLUGIN_VERSION = "5.0.0-stable"; // Also update 'config.gradle#defaultVersion'
 
 // Set of supported vendors
 static const char *META_VENDOR_NAME = "meta";


### PR DESCRIPTION
I added two of the changes since -rc1 to the `CHANGES.md`, but they aren't _super_ note-worthy, so I'm not entirely sure they are needed. If folks think they should be omitted, I can remove them and just do the version update