### PR TITLE
Make `godot_openxr_vendors::Recommendation` destructor virtual

### DIFF
--- a/plugin/src/main/cpp/editor/xr_project_setup_dialog.cpp
+++ b/plugin/src/main/cpp/editor/xr_project_setup_dialog.cpp
@@ -141,6 +141,7 @@ public:
 
 	Recommendation(String p_title, String p_description, String p_button_text, AlertType p_alert_type, ProjectType p_project_type, VendorType p_vendor_type, bool p_requires_restart) :
 			title(p_title), description(p_description), button_text(p_button_text), alert_type(p_alert_type), project_type(p_project_type), vendor_type(p_vendor_type), requires_restart(p_requires_restart) {}
+	virtual ~Recommendation() {}
 };
 
 class SimpleProjectSettingRecommendation : public Recommendation {


### PR DESCRIPTION
I happened to notice this compiler warning:

```
thirdparty/godot-cpp/include/godot_cpp/core/memory.hpp:107:3: warning: destructor called on 'godot_openxr_vendors::Recommendation' that is abstract but has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]
  107 |                 p_class->~T();
      |                 ^
plugin/src/main/cpp/editor/xr_project_setup_dialog.cpp:752:3: note: in instantiation of function template specialization 'godot::memdelete<godot_openxr_vendors::Recommendation>' requested here
  752 |                 memdelete(recommendation);
```

Definitely, doing `memdelete(Recommendation *)` means that we should make its destructor virtual.

However, since none of `Recommendation`'s child classes have destructors, it probably hasn't actually caused any problems