### PR TITLE
Bump version and update `CHANGES.md` for 5.0.1-stable release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change history for the Godot OpenXR loaders asset
 
+## 5.0.1
+
+- Fix crash when using space warp on Godot 4.7 (#487)
+- Make `godot_openxr_vendors::Recommendation` destructor virtual (#488)
+
 ## 5.0.0
 
 - Do not initialize light estimation extension if unsupported (#478)

--- a/config.gradle
+++ b/config.gradle
@@ -23,7 +23,7 @@ ext {
 
     // Parse the release version from the gradle project properties (e.g: -Prelease_version=<version>)
     getReleaseVersion = { ->
-        final String defaultVersion = "5.0.0-stable" // Also update 'plugin/src/main/cpp/include/export/export_plugin.h#PLUGIN_VERSION'
+        final String defaultVersion = "5.0.1-stable" // Also update 'plugin/src/main/cpp/include/export/export_plugin.h#PLUGIN_VERSION'
 
         String releaseVersion = project.hasProperty("release_version") ? project.property("release_version") : defaultVersion
         if (releaseVersion == null || releaseVersion.isEmpty()) {

--- a/plugin/src/main/cpp/include/export/export_plugin.h
+++ b/plugin/src/main/cpp/include/export/export_plugin.h
@@ -40,7 +40,7 @@
 
 using namespace godot;
 
-static const char *PLUGIN_VERSION = "5.0.0-stable"; // Also update 'config.gradle#defaultVersion'
+static const char *PLUGIN_VERSION = "5.0.1-stable"; // Also update 'config.gradle#defaultVersion'
 
 // Set of supported vendors
 static const char *META_VENDOR_NAME = "meta";


### PR DESCRIPTION
The changelog entries are based on `git log --oneline 5.0.0-stable..`

I'd like to do this release soon-ish, so that we can merge some of the feature PRs to spend a bit of time in `master` before we make the 5.1.0 release