### PR TITLE
Add the Meta anchor API permission when the scene API is enabled

### DIFF
--- a/plugin/src/main/cpp/export/meta_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/meta_export_plugin.cpp
@@ -405,8 +405,9 @@ String MetaEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 		}
 	}
 
-	// Check for anchor api
+	// Check for EXT spatial entities, or the Meta anchor or scene APIs.
 	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/spatial_entity/enabled") ||
+			(bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/scene_api") ||
 			(bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/anchor_api")) {
 		contents += "    <uses-permission android:name=\"com.oculus.permission.USE_ANCHOR_API\" />\n";
 	}


### PR DESCRIPTION
Per @BastiaanOlij's experience on stream, the anchor API permission may be needed, even if you only want to use the scene API