### PR TITLE
Docs: Fix path to Android XR Dynamic Resolution image

### DIFF
--- a/docs/manual/androidxr/dynamic_resolution.rst
+++ b/docs/manual/androidxr/dynamic_resolution.rst
@@ -10,4 +10,4 @@ Project Settings
 Dynamic Resolution is enabled by default. The extension setting can be found in **Project Settings** under the **OpenXR** section.
 The **Dynamic Resolution** setting should be listed under **Extensions** in the **Android XR** subcategory.
 
-.. image:: img/dynamic_resolution/dynamic_resolution_project_setting.png
+.. image:: img/dynamic_resolution/dynamic_resolution_project_settings.png


### PR DESCRIPTION
While testing out https://github.com/GodotVR/godot_openxr_vendors/pull/493, I noticed this error:

```
godot_openxr_vendors/docs/manual/androidxr/dynamic_resolution.rst:13: WARNING: image file not readable: manual/androidxr/img/dynamic_resolution/dynamic_resolution_project_setting.png
```

This PR fixes it!