### PR TITLE
[4.3] Bump version and update `CHANGES.md` for 4.3.1-stable release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change history for the Godot OpenXR loaders asset
 
+## 4.3.1
+
+- Fix crash when using space warp on Godot 4.7 (#489)
+- Fix environment depth extensions (#448)
+
 ## 4.3.0
 
 - Fix issue with instant splash screen

--- a/config.gradle
+++ b/config.gradle
@@ -23,7 +23,7 @@ ext {
 
     // Parse the release version from the gradle project properties (e.g: -Prelease_version=<version>)
     getReleaseVersion = { ->
-        final String defaultVersion = "4.3.0-stable" // Also update 'plugin/src/main/cpp/include/export/export_plugin.h#PLUGIN_VERSION'
+        final String defaultVersion = "4.3.1-stable" // Also update 'plugin/src/main/cpp/include/export/export_plugin.h#PLUGIN_VERSION'
 
         String releaseVersion = project.hasProperty("release_version") ? project.property("release_version") : defaultVersion
         if (releaseVersion == null || releaseVersion.isEmpty()) {

--- a/plugin/src/main/cpp/include/export/export_plugin.h
+++ b/plugin/src/main/cpp/include/export/export_plugin.h
@@ -40,7 +40,7 @@
 
 using namespace godot;
 
-static const char *PLUGIN_VERSION = "4.3.0-stable"; // Also update 'config.gradle#defaultVersion'
+static const char *PLUGIN_VERSION = "4.3.1-stable"; // Also update 'config.gradle#defaultVersion'
 
 // Set of supported vendors
 static const char *META_VENDOR_NAME = "meta";


### PR DESCRIPTION
The changelog entries are based on `git log --oneline 4.3.0-stable..`

It assumes https://github.com/GodotVR/godot_openxr_vendors/pull/489 is merged, which I just retested on Godot 4.6.1 and 4.7-beta2. I'll merge that one once CI is finished running after my rebase