### PR TITLE
Fix permission handling in AndroidXR Depth Texture Extension

### DIFF
--- a/plugin/src/main/cpp/extensions/openxr_android_environment_depth_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_environment_depth_extension.cpp
@@ -245,7 +245,8 @@ void OpenXRAndroidEnvironmentDepthExtension::_on_session_created(uint64_t instan
 }
 
 void OpenXRAndroidEnvironmentDepthExtension::_on_session_destroyed() {
-	destroy_depth_provider();
+	stop_environment_depth();
+	supported_resolutions.clear();
 }
 
 void OpenXRAndroidEnvironmentDepthExtension::_on_pre_render() {
@@ -418,7 +419,7 @@ bool OpenXRAndroidEnvironmentDepthExtension::start_environment_depth() {
 			// android.permission.SCENE_UNDERSTANDING_FINE), since we have non-zero supported resolutions
 			// but we cannot create a swapchain from any of them
 			UtilityFunctions::printerr("OpenXR: Unable to create a swapchain from one of the supported resolutions; try granting this app android.permission.SCENE_UNDERSTANDING_FINE");
-			destroy_depth_provider();
+			stop_environment_depth();
 			return false;
 		}
 	}
@@ -779,11 +780,6 @@ void OpenXRAndroidEnvironmentDepthExtension::_free_swapchain(XrDepthSwapchainAND
 		OpenXRAndroidEnvironmentDepthExtension::get_singleton()->xrDestroyDepthSwapchainANDROID(p_swapchain);
 	}
 };
-
-void OpenXRAndroidEnvironmentDepthExtension::destroy_depth_provider() {
-	stop_environment_depth();
-	supported_resolutions.clear();
-}
 
 void OpenXRAndroidEnvironmentDepthExtension::DepthCameraData::reset() {
 	OpenXRAndroidEnvironmentDepthExtension::_free_swapchain(swapchain);

--- a/plugin/src/main/cpp/include/extensions/openxr_android_environment_depth_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_android_environment_depth_extension.h
@@ -161,7 +161,6 @@ private:
 
 	void update_reprojection_material(bool p_creation = false);
 
-	void destroy_depth_provider();
 	void _update_mesh();
 };
 

--- a/samples/androidxr-depth-texture-sample/main.gd
+++ b/samples/androidxr-depth-texture-sample/main.gd
@@ -17,6 +17,7 @@ var depth_mode: DepthMode = DepthMode.SMOOTH
 func _ready():
 	super._ready()
 
+	get_tree().on_request_permissions_result.connect(_on_request_permissions_result)
 	OS.request_permissions()
 
 	xr_interface.session_begun.connect(_update)
@@ -26,6 +27,11 @@ func _process(_delta: float) -> void:
 	# Can't use "Show When Tracked" because we only want to show the hands in SMOOTH mode.
 	left_hand.visible = (left_hand.get_has_tracking_data() and depth_mode == DepthMode.SMOOTH)
 	right_hand.visible = (right_hand.get_has_tracking_data() and depth_mode == DepthMode.SMOOTH)
+
+
+func _on_request_permissions_result(p_permission: String, p_granted: bool) -> void:
+	if p_permission == "android.permission.SCENE_UNDERSTANDING_FINE" and p_granted:
+		_update()
 
 
 func _update() -> void:


### PR DESCRIPTION
On starting app that uses depth extension for the first time, permission prompts are displayed. As necessary permissions are absent during this period, depth texture extension fails to fully initialize. Specifically, supported depth buffer resolutions are successfully populated but further operations fail.

Discarding the resolutions on this failure prevents recovering from this state.

This patch also updates the depth texture sample to recover on initial run after permission is granted.