### PR TITLE
Add logic to manage XR Streaming client in supported scenarios

### DIFF
--- a/plugin/src/main/cpp/editor_debugger_plugin.cpp
+++ b/plugin/src/main/cpp/editor_debugger_plugin.cpp
@@ -29,7 +29,10 @@
 
 #include "editor_debugger_plugin.h"
 
+#include <godot_cpp/classes/editor_debugger_session.hpp>
 #include <godot_cpp/classes/editor_interface.hpp>
+
+#include "openxr_android_xrs_utils.h"
 
 void OpenXRVendorsEditorDebuggerPlugin::_bind_methods() {
 }
@@ -46,8 +49,26 @@ bool OpenXRVendorsEditorDebuggerPlugin::_capture(const String &p_message, const 
 		return true;
 	}
 
+	if (p_message == "godot_openxr_vendors:request_stop_xrs_client_on_session_end") {
+		// We do not currently support multiple debug sessions that require streaming client.
+		ERR_FAIL_COND_V(_stop_xrs_on_session_end_active, false);
+		_stop_xrs_on_session_end_active = true;
+
+		if (!get_session(p_session_id)->is_connected("stopped", callable_mp(this, &OpenXRVendorsEditorDebuggerPlugin::_on_session_stop))) {
+			get_session(p_session_id)->connect("stopped", callable_mp(this, &OpenXRVendorsEditorDebuggerPlugin::_on_session_stop));
+		}
+		return true;
+	}
+
 	return false;
 }
 
 OpenXRVendorsEditorDebuggerPlugin::OpenXRVendorsEditorDebuggerPlugin() {
+}
+
+void OpenXRVendorsEditorDebuggerPlugin::_on_session_stop() {
+	if (_stop_xrs_on_session_end_active) {
+		OpenXRAndroidXRSUtils::cleanup_xrs_client();
+		_stop_xrs_on_session_end_active = false;
+	}
 }

--- a/plugin/src/main/cpp/editor_plugin.cpp
+++ b/plugin/src/main/cpp/editor_plugin.cpp
@@ -39,8 +39,11 @@
 #include "export/validation_layers_export_plugin.h"
 
 #include <godot_cpp/classes/button.hpp>
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/editor_settings.hpp>
 #include <godot_cpp/classes/http_request.hpp>
 #include <godot_cpp/classes/line_edit.hpp>
+#include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/popup_menu.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/classes/scene_tree.hpp>
@@ -102,6 +105,8 @@ void OpenXRVendorsEditorPlugin::_notification(uint32_t p_what) {
 
 			debugger_plugin.instantiate();
 			add_debugger_plugin(debugger_plugin);
+
+			_add_plugin_editor_settings();
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
@@ -116,6 +121,26 @@ void OpenXRVendorsEditorPlugin::_notification(uint32_t p_what) {
 			debugger_plugin.unref();
 		} break;
 	}
+}
+
+void OpenXRVendorsEditorPlugin::_add_plugin_editor_settings() {
+	EditorInterface *editor_interface = EditorInterface::get_singleton();
+	ERR_FAIL_COND(editor_interface == nullptr);
+
+	Ref<EditorSettings> editor_settings = editor_interface->get_editor_settings();
+	ERR_FAIL_COND(editor_settings.is_null());
+
+	String auto_start_client_setting = "xr/openxr/androidxr/auto_start_androidxr_streaming_client";
+	if (!editor_settings->has_setting(auto_start_client_setting)) {
+		editor_settings->set_setting(auto_start_client_setting, true);
+	}
+
+	editor_settings->set_initial_value(auto_start_client_setting, true, false);
+	Dictionary property_info;
+	property_info["name"] = auto_start_client_setting;
+	property_info["type"] = Variant::Type::BOOL;
+	property_info["hint"] = PROPERTY_HINT_NONE;
+	editor_settings->add_property_info(property_info);
 }
 
 void OpenXRVendorsEditorPlugin::_open_project_setup() {
@@ -299,32 +324,38 @@ void OpenXRVendorsEditorPlugin::open_export_dialog() {
 }
 
 PackedStringArray OpenXRVendorsEditorPlugin::_run_scene(const String &p_scene, const PackedStringArray &p_args) const {
-	if (!ProjectSettings::get_singleton()->get_setting_with_override("xr/hybrid_app/enabled")) {
-		return p_args;
-	}
-
-	// If the XR mode is set explicitly, then let it be.
-	if (p_args.find("--xr-mode") != -1) {
-		return p_args;
-	}
-
-	const PackedStringArray &override_arguments = debugger_plugin->get_override_arguments();
-
 	PackedStringArray new_args = p_args;
-	if (override_arguments.size() > 0) {
-		new_args.append_array(override_arguments);
-		debugger_plugin->clear_override_arguments();
-	} else {
-		OpenXRHybridApp::HybridMode hybrid_mode = (OpenXRHybridApp::HybridMode)(int)ProjectSettings::get_singleton()->get_setting_with_override("xr/hybrid_app/launch_mode");
 
-		if (hybrid_mode == OpenXRHybridApp::HYBRID_MODE_IMMERSIVE) {
-			new_args.push_back("--xr-mode");
-			new_args.push_back("on");
-			new_args.push_back("--xr_mode_openxr");
-		} else if (hybrid_mode == OpenXRHybridApp::HYBRID_MODE_PANEL) {
-			new_args.push_back("--xr-mode");
-			new_args.push_back("off");
-			new_args.push_back("--xr_mode_regular");
+	// Only make changes if hybrid app setting is enabled and if xr mode is not set explicitly
+	if (ProjectSettings::get_singleton()->get_setting_with_override("xr/hybrid_app/enabled") && p_args.find("--xr-mode") == -1) {
+		const PackedStringArray &override_arguments = debugger_plugin->get_override_arguments();
+
+		if (override_arguments.size() > 0) {
+			new_args.append_array(override_arguments);
+			debugger_plugin->clear_override_arguments();
+		} else {
+			OpenXRHybridApp::HybridMode hybrid_mode = (OpenXRHybridApp::HybridMode)(int)ProjectSettings::get_singleton()->get_setting_with_override("xr/hybrid_app/launch_mode");
+
+			if (hybrid_mode == OpenXRHybridApp::HYBRID_MODE_IMMERSIVE) {
+				new_args.push_back("--xr-mode");
+				new_args.push_back("on");
+				new_args.push_back("--xr_mode_openxr");
+			} else if (hybrid_mode == OpenXRHybridApp::HYBRID_MODE_PANEL) {
+				new_args.push_back("--xr-mode");
+				new_args.push_back("off");
+				new_args.push_back("--xr_mode_regular");
+			}
+		}
+	}
+
+	// Add a commandline arg to enable the child process to autostart (and autostop) androidxr streaming client on compatible Android XR devices.
+	EditorInterface *editor_interface = EditorInterface::get_singleton();
+	if (editor_interface != nullptr) {
+		Ref<EditorSettings> editor_settings = editor_interface->get_editor_settings();
+		if (editor_settings.is_valid() && editor_settings->get_setting("xr/openxr/androidxr/auto_start_androidxr_streaming_client") && ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/enabled")) {
+			// ANDROID_HOME path can be overrided in the godot editor. The debugged process has to respect this override.
+			OS::get_singleton()->set_environment("ANDROID_HOME", editor_settings->get_setting("export/android/android_sdk_path"));
+			new_args.push_back("--xr_auto_start_androidxr_streaming_client");
 		}
 	}
 

--- a/plugin/src/main/cpp/extensions/openxr_session_helper_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_session_helper_extension.cpp
@@ -1,0 +1,97 @@
+/**************************************************************************/
+/*  openxr_session_helper_extension.cpp                                   */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "extensions/openxr_session_helper_extension.h"
+
+#include <godot_cpp/classes/engine_debugger.hpp>
+#include <godot_cpp/classes/open_xr_interface.hpp>
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/classes/xr_server.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include "openxr_android_xrs_utils.h"
+
+using namespace godot;
+
+OpenXRSessionHelperExtension *OpenXRSessionHelperExtension::singleton = nullptr;
+
+OpenXRSessionHelperExtension *OpenXRSessionHelperExtension::get_singleton() {
+	if (singleton == nullptr) {
+		memnew(OpenXRSessionHelperExtension());
+	}
+	return singleton;
+}
+
+OpenXRSessionHelperExtension::OpenXRSessionHelperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRSessionHelperExtension singleton already exists.");
+	singleton = this;
+}
+
+OpenXRSessionHelperExtension::~OpenXRSessionHelperExtension() {
+	singleton = nullptr;
+}
+
+void OpenXRSessionHelperExtension::_on_instance_created(uint64_t instance) {
+	GDEXTENSION_INIT_XR_FUNC(xrGetInstanceProperties);
+
+	if (OS::get_singleton()->get_cmdline_args().has("--xr_auto_start_androidxr_streaming_client") && _get_openxr_runtime_name((XrInstance)instance) == OpenXRAndroidXRSUtils::get_xrs_runtime_name()) {
+		UtilityFunctions::print_verbose("OpenXRSessionHelperExtension: Android XR Streaming runtime detected, will attempt to start client");
+		_should_request_stop_xrs_client = OpenXRAndroidXRSUtils::try_init_xrs_client();
+	}
+}
+
+void OpenXRSessionHelperExtension::_on_state_ready() {
+	if (_should_request_stop_xrs_client) {
+		EngineDebugger *engine_debugger = EngineDebugger::get_singleton();
+		if (engine_debugger && engine_debugger->is_active()) {
+			engine_debugger->send_message("godot_openxr_vendors:request_stop_xrs_client_on_session_end", {});
+			_should_request_stop_xrs_client = false;
+		}
+	}
+}
+
+void OpenXRSessionHelperExtension::_bind_methods() {}
+
+String OpenXRSessionHelperExtension::_get_openxr_runtime_name(XrInstance instance) {
+	XrInstanceProperties instanceProps = {
+		XR_TYPE_INSTANCE_PROPERTIES, // type;
+		nullptr, // next
+		0, // runtimeVersion, from here will be set by our get call
+		"" // runtimeName
+	};
+
+	XrResult result = xrGetInstanceProperties((XrInstance)instance, &instanceProps);
+	if (XR_FAILED(result)) {
+		UtilityFunctions::printerr(vformat("OpenXRSessionHelperExtension: xrGetInstanceProperties failed: %s", get_openxr_api()->get_error_string(result)));
+		return "";
+	}
+
+	return instanceProps.runtimeName;
+}

--- a/plugin/src/main/cpp/include/editor_debugger_plugin.h
+++ b/plugin/src/main/cpp/include/editor_debugger_plugin.h
@@ -38,6 +38,10 @@ class OpenXRVendorsEditorDebuggerPlugin : public EditorDebuggerPlugin {
 
 	PackedStringArray override_arguments;
 
+	bool _stop_xrs_on_session_end_active = false;
+
+	void _on_session_stop();
+
 protected:
 	static void _bind_methods();
 

--- a/plugin/src/main/cpp/include/extensions/openxr_session_helper_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_session_helper_extension.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_plugin.h                                                       */
+/*  openxr_session_helper_extension.h                                     */
 /**************************************************************************/
 /*                       This file is part of:                            */
 /*                              GODOT XR                                  */
@@ -27,53 +27,41 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#ifndef OPENXR_SESSION_HELPER_EXTENSION_H
+#define OPENXR_SESSION_HELPER_EXTENSION_H
 
-#include <godot_cpp/classes/editor_export_plugin.hpp>
-#include <godot_cpp/classes/editor_plugin.hpp>
+#include <openxr/openxr.h>
+#include <godot_cpp/classes/open_xr_extension_wrapper.hpp>
+#include <godot_cpp/variant/packed_string_array.hpp>
 
-#include "editor_debugger_plugin.h"
+#include "util.h"
 
 using namespace godot;
-class XrProjectSetupDialog;
 
-namespace godot {
-class LineEdit;
-}
+class OpenXRSessionHelperExtension : public OpenXRExtensionWrapper {
+	GDCLASS(OpenXRSessionHelperExtension, OpenXRExtensionWrapper);
 
-class OpenXRVendorsEditorPlugin : public EditorPlugin {
-	GDCLASS(OpenXRVendorsEditorPlugin, EditorPlugin)
+public:
+	static OpenXRSessionHelperExtension *get_singleton();
 
-	static OpenXRVendorsEditorPlugin *singleton;
+	OpenXRSessionHelperExtension();
+	virtual ~OpenXRSessionHelperExtension() override;
 
-	Vector<Ref<EditorExportPlugin>> export_plugins;
-	Ref<OpenXRVendorsEditorDebuggerPlugin> debugger_plugin;
-
-	XrProjectSetupDialog *_xr_project_setup_dialog = nullptr;
-
-	void _add_export_plugin(const Ref<EditorExportPlugin> &p_plugin);
-
-	void _open_project_setup();
-
-	void _add_plugin_editor_settings();
+	virtual void _on_instance_created(uint64_t instance) override;
+	virtual void _on_state_ready() override;
 
 protected:
 	static void _bind_methods();
 
-	void _notification(uint32_t p_what);
+private:
+	// Vars for initializing extension
+	static OpenXRSessionHelperExtension *singleton;
 
-public:
-	static OpenXRVendorsEditorPlugin *get_singleton();
+	bool _should_request_stop_xrs_client = false;
 
-	void open_asset_library(const String &p_filter_string);
-	void _on_asset_library_request_completed(int p_result, int p_response_code, const PackedStringArray &p_headers, const PackedByteArray &p_body, LineEdit *p_asset_library_filter, String p_search_string);
+	String _get_openxr_runtime_name(XrInstance instance);
 
-	void open_project_settings(const String &p_filter_string);
-
-	void open_export_dialog();
-
-	PackedStringArray _run_scene(const String &p_scene, const PackedStringArray &p_args) const override;
-
-	OpenXRVendorsEditorPlugin();
-	~OpenXRVendorsEditorPlugin();
+	EXT_PROTO_XRRESULT_FUNC2(xrGetInstanceProperties, (XrInstance), instance, (XrInstanceProperties *), instanceProperties);
 };
+
+#endif // OPENXR_SESSION_HELPER_EXTENSION_H

--- a/plugin/src/main/cpp/include/openxr_android_xrs_utils.h
+++ b/plugin/src/main/cpp/include/openxr_android_xrs_utils.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_plugin.h                                                       */
+/*  openxr_android_xrs_utils.h                                            */
 /**************************************************************************/
 /*                       This file is part of:                            */
 /*                              GODOT XR                                  */
@@ -29,51 +29,10 @@
 
 #pragma once
 
-#include <godot_cpp/classes/editor_export_plugin.hpp>
-#include <godot_cpp/classes/editor_plugin.hpp>
+#include <godot_cpp/variant/string.hpp>
 
-#include "editor_debugger_plugin.h"
-
-using namespace godot;
-class XrProjectSetupDialog;
-
-namespace godot {
-class LineEdit;
-}
-
-class OpenXRVendorsEditorPlugin : public EditorPlugin {
-	GDCLASS(OpenXRVendorsEditorPlugin, EditorPlugin)
-
-	static OpenXRVendorsEditorPlugin *singleton;
-
-	Vector<Ref<EditorExportPlugin>> export_plugins;
-	Ref<OpenXRVendorsEditorDebuggerPlugin> debugger_plugin;
-
-	XrProjectSetupDialog *_xr_project_setup_dialog = nullptr;
-
-	void _add_export_plugin(const Ref<EditorExportPlugin> &p_plugin);
-
-	void _open_project_setup();
-
-	void _add_plugin_editor_settings();
-
-protected:
-	static void _bind_methods();
-
-	void _notification(uint32_t p_what);
-
-public:
-	static OpenXRVendorsEditorPlugin *get_singleton();
-
-	void open_asset_library(const String &p_filter_string);
-	void _on_asset_library_request_completed(int p_result, int p_response_code, const PackedStringArray &p_headers, const PackedByteArray &p_body, LineEdit *p_asset_library_filter, String p_search_string);
-
-	void open_project_settings(const String &p_filter_string);
-
-	void open_export_dialog();
-
-	PackedStringArray _run_scene(const String &p_scene, const PackedStringArray &p_args) const override;
-
-	OpenXRVendorsEditorPlugin();
-	~OpenXRVendorsEditorPlugin();
-};
+namespace OpenXRAndroidXRSUtils {
+bool try_init_xrs_client();
+void cleanup_xrs_client();
+godot::String get_xrs_runtime_name();
+} //namespace OpenXRAndroidXRSUtils

--- a/plugin/src/main/cpp/openxr_android_xrs_utils.cpp
+++ b/plugin/src/main/cpp/openxr_android_xrs_utils.cpp
@@ -1,0 +1,123 @@
+/**************************************************************************/
+/*  openxr_android_xrs_utils.cpp                                          */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "openxr_android_xrs_utils.h"
+
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/editor_settings.hpp>
+#include <godot_cpp/classes/os.hpp>
+
+constexpr char XRS_RUNTIME_NAME[] = "Android XR Streaming";
+
+constexpr char XRS_CLIENT_PACKAGE[] = "com.google.vr.streaming.client";
+constexpr char XRS_CLIENT_ACTIVITY[] = "com.google.vr.streaming.client.XrStreamingActivity";
+
+using namespace godot;
+
+namespace {
+String get_android_home_from_environment() {
+	return OS::get_singleton()->get_environment("ANDROID_HOME");
+}
+
+String get_android_home_from_editor_settings() {
+	EditorInterface *editor_interface = EditorInterface::get_singleton();
+	ERR_FAIL_COND_V(editor_interface == nullptr, "");
+
+	Ref<EditorSettings> editor_settings = editor_interface->get_editor_settings();
+	ERR_FAIL_COND_V(editor_settings.is_null(), "");
+
+	return editor_settings->get_setting("export/android/android_sdk_path");
+}
+
+// This method is called from the debugged application as well as the editor process
+String get_adb_path() {
+	// In the editor, we have access to Editor settings and can get adb path from there.
+	// But, in the debugged application, we rely on environment variables for getting adb path.
+	// This is because EditorSettings interface is not available when this method is called.
+	String android_home = OS::get_singleton()->has_feature("editor_hint") ? get_android_home_from_editor_settings() : get_android_home_from_environment();
+	ERR_FAIL_COND_V(android_home.is_empty(), "");
+
+	String exe_ext;
+	if (OS::get_singleton()->get_name() == "Windows") {
+		exe_ext = ".exe";
+	}
+
+	String adb_path = android_home.path_join("platform-tools/adb" + exe_ext);
+	return adb_path;
+}
+} // anonymous namespace
+
+namespace OpenXRAndroidXRSUtils {
+// Function returns true only if it was responsible for starting the AndroidXR streaming client.
+// If client was not found or client was already running, it returns false to indicate stopping the client should not be attempted.
+bool try_init_xrs_client() {
+	String adb = get_adb_path();
+	ERR_FAIL_COND_V(adb.is_empty(), false);
+
+	// Ensure the server is up and running for further commands, we don't care about output here.
+	OS::get_singleton()->execute(adb, { "start-server" });
+
+	Array output;
+	OS::get_singleton()->execute(adb, { "shell", "pm list packages" }, output);
+	if (!((String)output.back()).contains(XRS_CLIENT_PACKAGE)) {
+		UtilityFunctions::printerr("OpenXRSessionHelperExtension: Android XR Streaming client not installed on device");
+		return false;
+	}
+
+	output.clear();
+	OS::get_singleton()->execute(adb, { "shell", "dumpsys activity activities | grep ResumedActivity" }, output);
+	if (((String)output.back()).contains(XRS_CLIENT_PACKAGE)) {
+		// AndroidXR streaming client already running and in focus, doing nothing
+		return false;
+	}
+
+	output.clear();
+	OS::get_singleton()->execute(adb, { "shell", "dumpsys activity activities | grep ActivityRecord" }, output);
+	bool client_is_already_running = ((String)output.back()).contains(XRS_CLIENT_PACKAGE);
+
+	// This starts the client if it was not running before, or brings it to focus if it was already running.
+	UtilityFunctions::print_verbose("Attempting to start AndroidXR streaming client on connected device");
+	OS::get_singleton()->execute_with_pipe(adb, { "shell", vformat("am start -n %s/%s", XRS_CLIENT_PACKAGE, XRS_CLIENT_ACTIVITY) }, false);
+
+	// return value indicates if this function was responsible for starting the client.
+	return !client_is_already_running;
+}
+
+void cleanup_xrs_client() {
+	String adb = get_adb_path();
+	ERR_FAIL_COND(adb.is_empty());
+
+	PackedStringArray args = { "shell", vformat("am force-stop %s", XRS_CLIENT_PACKAGE) };
+	OS::get_singleton()->execute(adb, args);
+}
+
+String get_xrs_runtime_name() {
+	return XRS_RUNTIME_NAME;
+}
+} //namespace OpenXRAndroidXRSUtils

--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -98,6 +98,7 @@
 #include "extensions/openxr_meta_simultaneous_hands_and_controllers_extension.h"
 #include "extensions/openxr_meta_spatial_entity_mesh_extension.h"
 #include "extensions/openxr_ml_marker_understanding_extension.h"
+#include "extensions/openxr_session_helper_extension.h"
 #include "extensions/openxr_stationary_reference_space_extension.h"
 
 #include "classes/openxr_android_anchor_tracker.h"
@@ -178,6 +179,8 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 		case MODULE_INITIALIZATION_LEVEL_CORE: {
 			add_plugin_project_settings();
 
+			GDREGISTER_CLASS(OpenXRSessionHelperExtension);
+
 			GDREGISTER_ABSTRACT_CLASS(OpenXRVendorPerformanceMetricsProvider);
 			GDREGISTER_CLASS(OpenXRVendorPerformanceMetrics);
 			GDREGISTER_CLASS(OpenXRAndroidRecommendedResolutionExtension);
@@ -239,6 +242,8 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			GDREGISTER_CLASS(OpenXRMetaBoundaryVisibilityExtension);
 			GDREGISTER_CLASS(OpenXRStationaryReferenceSpaceExtension);
 #endif // META_HEADERS_ENABLED
+
+			_register_extension_with_openxr(OpenXRSessionHelperExtension::get_singleton());
 
 			if (_get_bool_project_setting("xr/openxr/extensions/meta/passthrough")) {
 				_register_extension_with_openxr(OpenXRFbPassthroughExtension::get_singleton());
@@ -422,6 +427,8 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			break;
 
 		case MODULE_INITIALIZATION_LEVEL_SCENE: {
+			_register_extension_as_singleton(OpenXRSessionHelperExtension::get_singleton());
+
 			_register_extension_as_singleton(OpenXRFbPassthroughExtension::get_singleton());
 			_register_extension_as_singleton(OpenXRFbRenderModelExtension::get_singleton());
 			_register_extension_as_singleton(OpenXRFbColorSpaceExtension::get_singleton());

--- a/thirdparty/godot_cpp_build_profile/build_profile.json
+++ b/thirdparty/godot_cpp_build_profile/build_profile.json
@@ -14,6 +14,7 @@
         "DirectionalLight3D",
         "DisplayServer",
         "EditorDebuggerPlugin",
+        "EditorDebuggerSession",
         "EditorExportPlatform",
         "EditorExportPlatformAndroid",
         "EditorExportPlugin",


### PR DESCRIPTION
XR Streaming client is auto started if the following conditions are met
1. XR/OpenXR/AndroidXR/Auto Start direct Preview Client is enabled in editor settings.
2. Android XR Streaming runtime is being used by app debugged in editor.
3. Android XR device is connected and is the only device adb can connect to. Scenarios where multiple devices are detected by adb is not handled.
4. XR Streaming client is installed on the connected device.

If client was not running on device before the debugged app is started, the client is started on app start, and closed on app exit.

If the client was running on device before the debugged app started, the client is brought into focus (if not already), but left open on app exit.

The debugged application relies on XrInstanceProperties.runtimeName to determine if XR Streaming runtime is being used. But before editor singletons are registered, allowing communication with debug interface, Godot halts, waiting for client connection. This forces us to start the client from the OpenXRExtensionWrapper implementation.

On exit, the debugged process is killed. As the cleanup functions are not called, the function to stop the client (when appropriate) is called from editor debugger plugin.