### PR TITLE
Bump version and update `CHANGES.md` for 5.1.0-stable release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,20 @@
 # Change history for the Godot OpenXR loaders asset
 
+## 5.1.0
+
+- Add manual page for Android XR Trackables (#499)
+- Automatically start Android XR Streaming client (#498)
+- Fix permission handling in Android XR Depth Texture Extension (#497)
+- Implement `XR_ANDROID_device_anchor_persistence_extension` (#457)
+- Implement `XR_ANDROID_raycast` (#456)
+- Implement `XR_ANDROID_trackables_object` (#466)
+- Implement `XR_ANDROID_trackables` (#455)
+- Add documentation for the OpenXR validation layers (#496)
+- Improvements to the documentation / README (#492 / #493 / #494)
+- Add the Meta anchor API permission when the scene API is enabled (#491)
+- Add support for the composition layer extensions to the main projection layer (#464)
+- Implement `XR_ANDROID_mouse_interaction` (#474)
+
 ## 5.0.1
 
 - Fix crash when using space warp on Godot 4.7 (#487)
@@ -29,6 +44,11 @@
 - Add `XR_META_hand_tracking_microgestures` to hand tracking sample (#340)
 - Stop using deprecated `OpenXRExtensionWrapperExtension` and rename `*ExtensionWrapper` to `*Extension` (#414)
 - Update to support Godot 4.6+ (#407)
+
+## 4.3.1
+
+- Fix crash when using space warp on Godot 4.7 (#489)
+- Fix environment depth extensions (#448)
 
 ## 4.3.0
 

--- a/config.gradle
+++ b/config.gradle
@@ -23,7 +23,7 @@ ext {
 
     // Parse the release version from the gradle project properties (e.g: -Prelease_version=<version>)
     getReleaseVersion = { ->
-        final String defaultVersion = "5.0.1-stable" // Also update 'plugin/src/main/cpp/include/export/export_plugin.h#PLUGIN_VERSION'
+        final String defaultVersion = "5.1.0-stable" // Also update 'plugin/src/main/cpp/include/export/export_plugin.h#PLUGIN_VERSION'
 
         String releaseVersion = project.hasProperty("release_version") ? project.property("release_version") : defaultVersion
         if (releaseVersion == null || releaseVersion.isEmpty()) {

--- a/plugin/src/main/cpp/include/export/export_plugin.h
+++ b/plugin/src/main/cpp/include/export/export_plugin.h
@@ -40,7 +40,7 @@
 
 using namespace godot;
 
-static const char *PLUGIN_VERSION = "5.0.1-stable"; // Also update 'config.gradle#defaultVersion'
+static const char *PLUGIN_VERSION = "5.1.0-stable"; // Also update 'config.gradle#defaultVersion'
 
 // Set of supported vendors
 static const char *META_VENDOR_NAME = "meta";


### PR DESCRIPTION
The changelog entries are based on `git log --oneline 5.1.0-stable..`, but also include entries assuming that these PRs will be merged too:

- https://github.com/GodotVR/godot_openxr_vendors/pull/498
- https://github.com/GodotVR/godot_openxr_vendors/pull/499

I also pulled in the changelog entries for 4.3.1 from https://github.com/GodotVR/godot_openxr_vendors/pull/495