### PR TITLE
Handle runtime changes to app permissions in face and eye tracking extensions

### DIFF
--- a/plugin/src/main/cpp/extensions/openxr_android_eye_tracking_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_eye_tracking_extension.cpp
@@ -34,6 +34,7 @@
 #include <godot_cpp/classes/open_xrapi_extension.hpp>
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/core/error_macros.hpp>
 
 #include "util.h"
 
@@ -53,8 +54,6 @@ OpenXRAndroidEyeTrackingExtension::OpenXRAndroidEyeTrackingExtension() {
 
 	singleton = this;
 	request_extensions[XR_ANDROID_EYE_TRACKING_EXTENSION_NAME] = &available;
-
-	on_request_permissions_result_callable = callable_mp(this, &OpenXRAndroidEyeTrackingExtension::_on_request_permissions_result);
 }
 
 OpenXRAndroidEyeTrackingExtension::~OpenXRAndroidEyeTrackingExtension() {
@@ -90,24 +89,25 @@ void OpenXRAndroidEyeTrackingExtension::_on_instance_created(uint64_t p_instance
 	}
 }
 
-void OpenXRAndroidEyeTrackingExtension::_on_session_created(uint64_t instance) {
+void OpenXRAndroidEyeTrackingExtension::_on_state_focused() {
+	// Creating tracker in _on_state_focused allows handling the following scenarios
+	// 1. During first app launch when permissions are granted from the prompt interactively.
+	// 2. If the permissions are initially denied, but granted from app settings while app is running.
+
 	if (!available || !eye_tracking_properties.supportsEyeTracking) {
 		return;
 	}
 
-	_try_create_eye_tracker();
-}
-
-void OpenXRAndroidEyeTrackingExtension::_on_request_permissions_result(const String &p_permission, bool p_granted) {
-	if (!available || p_permission != "android.permission.EYE_TRACKING_COARSE" || !p_granted) {
+	if (eye_tracker != XR_NULL_HANDLE) {
 		return;
 	}
 
-	_try_create_eye_tracker();
-}
+	OS *os = OS::get_singleton();
+	ERR_FAIL_NULL(os);
 
-void OpenXRAndroidEyeTrackingExtension::_try_create_eye_tracker() {
-	if (eye_tracker != XR_NULL_HANDLE) {
+	PackedStringArray granted_permissions = os->get_granted_permissions();
+	if (!granted_permissions.has("android.permission.EYE_TRACKING_COARSE") && !granted_permissions.has("android.permission.EYE_TRACKING_FINE")) {
+		WARN_PRINT("OpenXR: XR_ANDROID_eye_tracking requires android.permission.EYE_TRACKING_COARSE or android.permission.EYE_TRACKING_FINE; waiting for it to be granted before enabling");
 		return;
 	}
 
@@ -142,15 +142,6 @@ bool OpenXRAndroidEyeTrackingExtension::_initialize_openxr_android_eye_tracking_
 }
 
 void OpenXRAndroidEyeTrackingExtension::_bind_methods() {
-}
-
-void OpenXRAndroidEyeTrackingExtension::_on_state_ready() {
-	if (available && eye_tracking_properties.supportsEyeTracking) {
-		MainLoop *main_loop = Engine::get_singleton()->get_main_loop();
-		if (main_loop && !main_loop->is_connected("on_request_permissions_result", on_request_permissions_result_callable)) {
-			main_loop->connect("on_request_permissions_result", on_request_permissions_result_callable);
-		}
-	}
 }
 
 void OpenXRAndroidEyeTrackingExtension::_on_process() {

--- a/plugin/src/main/cpp/extensions/openxr_android_face_tracking_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_face_tracking_extension.cpp
@@ -32,6 +32,8 @@
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/main_loop.hpp>
 #include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/core/error_macros.hpp>
 
 using namespace godot;
 
@@ -54,8 +56,6 @@ OpenXRAndroidFaceTrackingExtension::OpenXRAndroidFaceTrackingExtension() {
 
 	singleton = this;
 	request_extensions[XR_ANDROID_FACE_TRACKING_EXTENSION_NAME] = &available;
-
-	on_request_permissions_result_callable = callable_mp(this, &OpenXRAndroidFaceTrackingExtension::_on_request_permissions_result);
 }
 
 OpenXRAndroidFaceTrackingExtension::~OpenXRAndroidFaceTrackingExtension() {
@@ -85,24 +85,28 @@ void OpenXRAndroidFaceTrackingExtension::_on_instance_created(uint64_t p_instanc
 	}
 }
 
-void OpenXRAndroidFaceTrackingExtension::_on_session_created(uint64_t instance) {
+void OpenXRAndroidFaceTrackingExtension::_on_state_focused() {
+	// Creating tracker in _on_state_focused allows handling the following scenarios
+	// 1. During first app launch when permissions are granted from the prompt interactively.
+	// 2. If the permissions are initially denied, but granted from app settings while app is running.
+
 	if (!available || !face_tracking_properties.supportsFaceTracking) {
 		return;
 	}
 
-	_try_create_face_tracker();
-}
-
-void OpenXRAndroidFaceTrackingExtension::_on_request_permissions_result(const String &p_permission, bool p_granted) {
-	// On Android XR, if permission was granted during execution, we might want to re-attempt tracker creation.
-	if (p_permission != "android.permission.FACE_TRACKING" || !p_granted) {
+	if (face_tracker != XR_NULL_HANDLE) {
 		return;
 	}
 
-	_try_create_face_tracker();
-}
+	OS *os = OS::get_singleton();
+	ERR_FAIL_NULL(os);
 
-void OpenXRAndroidFaceTrackingExtension::_try_create_face_tracker() {
+	PackedStringArray granted_permissions = os->get_granted_permissions();
+	if (!granted_permissions.has("android.permission.FACE_TRACKING")) {
+		WARN_PRINT("OpenXR: XR_ANDROID_face_tracking requires android.permission.FACE_TRACKING; waiting for it to be granted before enabling");
+		return;
+	}
+
 	XrFaceTrackerCreateInfoANDROID create_info{
 		XR_TYPE_FACE_TRACKER_CREATE_INFO_ANDROID, // type
 		nullptr, // next
@@ -112,15 +116,6 @@ void OpenXRAndroidFaceTrackingExtension::_try_create_face_tracker() {
 	if (result != XR_SUCCESS) {
 		UtilityFunctions::printerr("OpenXR: Failed to create face tracker; ", get_openxr_api()->get_error_string(result));
 		face_tracker = XR_NULL_HANDLE;
-	}
-}
-
-void OpenXRAndroidFaceTrackingExtension::_on_state_ready() {
-	if (available && face_tracking_properties.supportsFaceTracking && face_tracker == XR_NULL_HANDLE) {
-		MainLoop *main_loop = Engine::get_singleton()->get_main_loop();
-		if (main_loop && !main_loop->is_connected("on_request_permissions_result", on_request_permissions_result_callable)) {
-			main_loop->connect("on_request_permissions_result", on_request_permissions_result_callable);
-		}
 	}
 }
 

--- a/plugin/src/main/cpp/include/extensions/openxr_android_eye_tracking_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_android_eye_tracking_extension.h
@@ -54,14 +54,11 @@ public:
 
 	virtual void _on_instance_created(uint64_t p_instance) override;
 
-	void _on_session_created(uint64_t instance) override;
+	void _on_state_focused() override;
+
 	virtual void _on_session_destroyed() override;
 
-	void _on_state_ready() override;
-
 	void _on_process() override;
-
-	void _on_request_permissions_result(const String &p_permission, bool p_granted);
 
 protected:
 	static void _bind_methods();
@@ -81,13 +78,10 @@ private:
 			(XrEyesANDROID *), eyesOutput);
 
 	bool _initialize_openxr_android_eye_tracking_extension();
-	void _try_create_eye_tracker();
 
 	void _populate_eye_tracker(XRControllerTracker *tracker, bool tracking_status, const XrEyeANDROID &xr_eye);
 
 	static OpenXRAndroidEyeTrackingExtension *singleton;
-
-	Callable on_request_permissions_result_callable;
 
 	HashMap<String, bool *> request_extensions;
 	bool available = false;

--- a/plugin/src/main/cpp/include/extensions/openxr_android_face_tracking_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_android_face_tracking_extension.h
@@ -54,14 +54,11 @@ public:
 
 	virtual void _on_instance_created(uint64_t p_instance) override;
 
-	void _on_session_created(uint64_t instance) override;
+	void _on_state_focused() override;
+
 	virtual void _on_session_destroyed() override;
 
-	void _on_state_ready() override;
-
 	void _on_process() override;
-
-	void _on_request_permissions_result(const String &p_permission, bool p_granted);
 
 	enum CalibrationState {
 		CALIBRATION_STATE_UNAVAILABLE = 0,
@@ -93,11 +90,8 @@ private:
 			(XrBool32 *), faceIsCalibratedOutput);
 
 	bool _initialize_openxr_android_face_tracking_extension();
-	void _try_create_face_tracker();
 
 	static OpenXRAndroidFaceTrackingExtension *singleton;
-
-	Callable on_request_permissions_result_callable;
 
 	HashMap<String, bool *> request_extensions;
 	bool available = false;


### PR DESCRIPTION
Creating tracker in _on_state_focused allows handling the following scenarios
1. During first app launch when permissions are granted from the prompt interactively.
2. If the permissions are initially denied, but granted from app settings while app is running.