### PR TITLE
Warn users that frame synthesis requires "Flip Y" on Android XR

### DIFF
--- a/plugin/src/main/cpp/export/android_xr_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/android_xr_export_plugin.cpp
@@ -142,6 +142,12 @@ String AndroidXREditorExportPlugin::_get_export_option_warning(const Ref<EditorE
 		if (!openxr_enabled && _get_bool_option(option)) {
 			return "\"Use experimental features\" is only valid when \"XR Mode\" is \"OpenXR\".\n";
 		}
+	} else if (option == "xr_features/enable_androidxr_plugin") {
+		if (godot::gdextension_interface::godot_version.minor >= 8) {
+			if ((bool)export_preset->get_project_setting("xr/openxr/extensions/frame_synthesis") && (String)export_preset->get_project_setting("rendering/renderer/rendering_method") != "gl_compatibility" && !(bool)export_preset->get_project_setting("xr/openxr/extensions/frame_synthesis/flip_y")) {
+				return "\"Frame Synthesis\" requires enabling \"Flip Y\" on Android XR when using Vulkan.\n";
+			}
+		}
 	}
 
 	return OpenXRVendorsEditorExportPlugin::_get_export_option_warning(platform, option);


### PR DESCRIPTION
Adds the warning suggested by @m4gr3d on https://github.com/godotengine/godot/pull/119056#issuecomment-4928242988

~~This also switches to using `EditorExportPreset::get_project_setting()` rather than `ProjectSettings::get_setting_with_override()` so that it takes into account settings that are using feature tags that are specific to the export preset. This way, it'll correctly see that `flip_y.androidxr` is enabled, even if `flip_y` (with no feature tag) is disabled.~~

~~We really should do this for all of our export plugins now that we depend on Godot 4.6+, but I'll do that in another PR~~

**UPDATE:** This PR is now rebased on https://github.com/GodotVR/godot_openxr_vendors/pull/509 which updates all our export plugins to use `EditorExportPreset::get_project_setting()`

Marking as DRAFT until these PRs are merged:

- https://github.com/GodotVR/godot_openxr_vendors/pull/509
- https://github.com/godotengine/godot/pull/119056