### PR TITLE
Use `EditorExportPreset::get_project_setting()` on export plugins

### DIFF
--- a/plugin/src/main/cpp/export/android_xr_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/android_xr_export_plugin.cpp
@@ -29,6 +29,7 @@
 
 #include "export/android_xr_export_plugin.h"
 
+#include <godot_cpp/classes/editor_export_preset.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
 
 using namespace godot;
@@ -122,15 +123,15 @@ String AndroidXREditorExportPlugin::_get_export_option_warning(const Ref<EditorE
 		return "";
 	}
 
-	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	Ref<EditorExportPreset> export_preset = get_export_preset();
 
 	bool openxr_enabled = _is_openxr_enabled();
 	if (option == "android_xr_features/eye_tracking") {
-		if (!openxr_enabled && ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/eye_gaze_interaction") || (bool)project_settings->get_setting_with_override("xr/openxr/extensions/androidxr/eye_tracking"))) {
+		if (!openxr_enabled && ((bool)export_preset->get_project_setting("xr/openxr/extensions/eye_gaze_interaction") || (bool)export_preset->get_project_setting("xr/openxr/extensions/androidxr/eye_tracking"))) {
 			return "\"Eye Tracking\" requires \"XR Mode\" to be \"OpenXR\".\n";
 		}
 	} else if (option == "android_xr_features/hand_tracking") {
-		if (!openxr_enabled && (bool)project_settings->get_setting_with_override("xr/openxr/extensions/hand_tracking")) {
+		if (!openxr_enabled && (bool)export_preset->get_project_setting("xr/openxr/extensions/hand_tracking")) {
 			return "\"Hand Tracking\" requires \"XR Mode\" to be \"OpenXR\".\n";
 		}
 	} else if (option == "android_xr_features/tracked_controllers") {
@@ -147,10 +148,12 @@ String AndroidXREditorExportPlugin::_get_export_option_warning(const Ref<EditorE
 }
 
 bool AndroidXREditorExportPlugin::_get_export_option_visibility(const Ref<godot::EditorExportPlatform> &p_platform, const godot::String &p_option) const {
+	Ref<EditorExportPreset> export_preset = get_export_preset();
+
 	if (p_option == "android_xr_features/eye_tracking") {
-		return (bool)ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/eye_gaze_interaction") || (bool)ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/androidxr/eye_tracking");
+		return (bool)export_preset->get_project_setting("xr/openxr/extensions/eye_gaze_interaction") || (bool)export_preset->get_project_setting("xr/openxr/extensions/androidxr/eye_tracking");
 	} else if (p_option == "android_xr_features/hand_tracking") {
-		return (bool)ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/hand_tracking");
+		return (bool)export_preset->get_project_setting("xr/openxr/extensions/hand_tracking");
 	}
 
 	return true;
@@ -224,7 +227,7 @@ String AndroidXREditorExportPlugin::_get_android_manifest_application_element_co
 
 	OpenXRHybridApp::HybridMode hybrid_launch_mode = _get_hybrid_app_launch_mode();
 	if (hybrid_launch_mode != OpenXRHybridApp::HYBRID_MODE_NONE) {
-		ProjectSettings *project_settings = ProjectSettings::get_singleton();
+		Ref<EditorExportPreset> export_preset = get_export_preset();
 
 		contents += vformat(
 				R"(
@@ -247,8 +250,8 @@ String AndroidXREditorExportPlugin::_get_android_manifest_application_element_co
 		</activity>
 )",
 				_bool_to_string(_get_bool_option("package/exclude_from_recents")),
-				_get_android_orientation_label((DisplayServer::ScreenOrientation)(int)project_settings->get_setting_with_override("display/window/handheld/orientation")),
-				_bool_to_string(project_settings->get_setting_with_override("display/window/size/resizable")));
+				_get_android_orientation_label((DisplayServer::ScreenOrientation)(int)export_preset->get_project_setting("display/window/handheld/orientation")),
+				_bool_to_string(export_preset->get_project_setting("display/window/size/resizable")));
 
 		if (hybrid_launch_mode == OpenXRHybridApp::HYBRID_MODE_PANEL) {
 			contents += R"(
@@ -287,11 +290,11 @@ String AndroidXREditorExportPlugin::_get_android_manifest_element_contents(const
 		contents += vformat("    <uses-feature android:name=\"android.hardware.xr.input.controller\" android:required=\"%s\" />\n", _bool_to_string(required));
 	}
 
-	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	Ref<EditorExportPreset> export_preset = get_export_preset();
 
 	// Check for eye tracking
-	bool eye_gaze_interaction_enabled = project_settings->get_setting_with_override("xr/openxr/extensions/eye_gaze_interaction");
-	bool eye_tracking_enabled = project_settings->get_setting_with_override("xr/openxr/extensions/androidxr/eye_tracking");
+	bool eye_gaze_interaction_enabled = export_preset->get_project_setting("xr/openxr/extensions/eye_gaze_interaction");
+	bool eye_tracking_enabled = export_preset->get_project_setting("xr/openxr/extensions/androidxr/eye_tracking");
 
 	if (eye_gaze_interaction_enabled) {
 		// XR_EXT_eye_gaze_interaction always requires EYE_TRACKING_FINE.
@@ -313,12 +316,12 @@ String AndroidXREditorExportPlugin::_get_android_manifest_element_contents(const
 	}
 
 	// Check for face tracking
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/androidxr/face_tracking")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/androidxr/face_tracking")) {
 		contents += "    <uses-permission android:name=\"android.permission.FACE_TRACKING\" />\n";
 	}
 
 	// Check for hand tracking
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/hand_tracking")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/hand_tracking")) {
 		contents += "    <uses-permission android:name=\"android.permission.HAND_TRACKING\" />\n";
 
 		int hand_tracking_value = _get_int_option("android_xr_features/hand_tracking", HAND_TRACKING_OPTIONAL_VALUE);
@@ -333,11 +336,11 @@ String AndroidXREditorExportPlugin::_get_android_manifest_element_contents(const
 	// When SCENE_UNDERSTANDING_FINE is requested, SCENE_UNDERSTANDING_COARSE is not needed.
 	// Spatial entity and most of scene understanding features only require
 	// SCENE_UNDERSTANDING_COARSE.
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/androidxr/environment_depth") || (bool)project_settings->get_setting_with_override("xr/openxr/extensions/androidxr/scene_meshing")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/androidxr/environment_depth") || (bool)export_preset->get_project_setting("xr/openxr/extensions/androidxr/scene_meshing")) {
 		contents += "    <uses-permission android:name=\"android.permission.SCENE_UNDERSTANDING_FINE\" />\n";
-	} else if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/spatial_entity/enabled") ||
-			(bool)project_settings->get_setting_with_override("xr/openxr/extensions/androidxr/light_estimation") ||
-			(bool)project_settings->get_setting_with_override("xr/openxr/extensions/androidxr/trackables")) {
+	} else if ((bool)export_preset->get_project_setting("xr/openxr/extensions/spatial_entity/enabled") ||
+			(bool)export_preset->get_project_setting("xr/openxr/extensions/androidxr/light_estimation") ||
+			(bool)export_preset->get_project_setting("xr/openxr/extensions/androidxr/trackables")) {
 		contents += "    <uses-permission android:name=\"android.permission.SCENE_UNDERSTANDING_COARSE\" />\n";
 	}
 

--- a/plugin/src/main/cpp/export/export_plugin.cpp
+++ b/plugin/src/main/cpp/export/export_plugin.cpp
@@ -30,7 +30,7 @@
 #include "export/export_plugin.h"
 
 #include <godot_cpp/classes/editor_export_platform_android.hpp>
-#include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/editor_export_preset.hpp>
 
 using namespace godot;
 
@@ -96,14 +96,14 @@ Dictionary OpenXRVendorsEditorExportPlugin::_get_vendor_toggle_option(const Stri
 }
 
 bool OpenXRVendorsEditorExportPlugin::_is_hybrid_app_enabled() const {
-	return ProjectSettings::get_singleton()->get_setting_with_override("xr/hybrid_app/enabled");
+	return get_export_preset()->get_project_setting("xr/hybrid_app/enabled");
 }
 
 OpenXRHybridApp::HybridMode OpenXRVendorsEditorExportPlugin::_get_hybrid_app_launch_mode() const {
 	if (!_is_hybrid_app_enabled()) {
 		return OpenXRHybridApp::HYBRID_MODE_NONE;
 	}
-	return (OpenXRHybridApp::HybridMode)(int)ProjectSettings::get_singleton()->get_setting_with_override("xr/hybrid_app/launch_mode");
+	return (OpenXRHybridApp::HybridMode)(int)get_export_preset()->get_project_setting("xr/hybrid_app/launch_mode");
 }
 
 String OpenXRVendorsEditorExportPlugin::_get_common_activity_intent_filter_contents() const {
@@ -173,7 +173,7 @@ PackedStringArray OpenXRVendorsEditorExportPlugin::_get_export_features(const Re
 	}
 
 	// Add the eye tracking feature if necessary
-	if ((bool)ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/eye_gaze_interaction")) {
+	if ((bool)get_export_preset()->get_project_setting("xr/openxr/extensions/eye_gaze_interaction")) {
 		features.append(EYE_GAZE_INTERACTION_FEATURE);
 	}
 

--- a/plugin/src/main/cpp/export/khronos_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/khronos_export_plugin.cpp
@@ -29,7 +29,7 @@
 
 #include "export/khronos_export_plugin.h"
 
-#include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/editor_export_preset.hpp>
 
 using namespace godot;
 
@@ -162,11 +162,11 @@ String KhronosEditorExportPlugin::_get_android_manifest_element_contents(const R
 		return contents;
 	}
 
-	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	Ref<EditorExportPreset> export_preset = get_export_preset();
 
 	if (_is_khronos_htc_enabled()) {
 		// Check for hand tracking
-		if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/hand_tracking")) {
+		if ((bool)export_preset->get_project_setting("xr/openxr/extensions/hand_tracking")) {
 			contents += "    <uses-feature tools:node=\"replace\" android:name=\"wave.feature.handtracking\" android:required=\"true\" />\n";
 		}
 
@@ -176,7 +176,7 @@ String KhronosEditorExportPlugin::_get_android_manifest_element_contents(const R
 		}
 
 		// Check for eye tracking
-		if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/eye_gaze_interaction")) {
+		if ((bool)export_preset->get_project_setting("xr/openxr/extensions/eye_gaze_interaction")) {
 			contents += "    <uses-feature tools:node=\"replace\" android:name=\"wave.feature.eyetracking\" android:required=\"true\" />\n";
 		}
 

--- a/plugin/src/main/cpp/export/magicleap_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/magicleap_export_plugin.cpp
@@ -29,7 +29,7 @@
 
 #include "export/magicleap_export_plugin.h"
 
-#include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/editor_export_preset.hpp>
 
 using namespace godot;
 
@@ -56,11 +56,13 @@ String MagicleapEditorExportPlugin::_get_android_manifest_element_contents(const
 		return contents;
 	}
 
-	if (ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/hand_tracking")) {
+	Ref<EditorExportPreset> export_preset = get_export_preset();
+
+	if (export_preset->get_project_setting("xr/openxr/extensions/hand_tracking")) {
 		contents += "    <uses-permission android:name=\"com.magicleap.permission.HAND_TRACKING\" />\n";
 	}
 
-	if (ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/magic_leap/marker_understanding")) {
+	if (export_preset->get_project_setting("xr/openxr/extensions/magic_leap/marker_understanding")) {
 		contents += "    <uses-permission android:name=\"com.magicleap.permission.MARKER_TRACKING\" />\n";
 	}
 

--- a/plugin/src/main/cpp/export/meta_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/meta_export_plugin.cpp
@@ -29,6 +29,7 @@
 
 #include "export/meta_export_plugin.h"
 
+#include <godot_cpp/classes/editor_export_preset.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/classes/xr_interface.hpp>
 
@@ -246,31 +247,31 @@ String MetaEditorExportPlugin::_get_export_option_warning(const Ref<EditorExport
 		return "";
 	}
 
-	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	Ref<EditorExportPreset> export_preset = get_export_preset();
 
 	bool openxr_enabled = _is_openxr_enabled();
 	if (option == "meta_xr_features/eye_tracking") {
-		if (!openxr_enabled && (bool)project_settings->get_setting_with_override("xr/openxr/extensions/eye_gaze_interaction")) {
+		if (!openxr_enabled && (bool)export_preset->get_project_setting("xr/openxr/extensions/eye_gaze_interaction")) {
 			return "\"Eye Tracking\" requires \"XR Mode\" to be \"OpenXR\".\n";
 		}
 	} else if (option == "meta_xr_features/face_tracking") {
-		if (!openxr_enabled && (bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/face_tracking")) {
+		if (!openxr_enabled && (bool)export_preset->get_project_setting("xr/openxr/extensions/meta/face_tracking")) {
 			return "\"Face Tracking\" requires \"XR Mode\" to be \"OpenXR\".\n";
 		}
 	} else if (option == "meta_xr_features/body_tracking") {
-		if (!openxr_enabled && (bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/body_tracking")) {
+		if (!openxr_enabled && (bool)export_preset->get_project_setting("xr/openxr/extensions/meta/body_tracking")) {
 			return "\"Body Tracking\" requires \"XR Mode\" to be \"OpenXR\".\n";
 		}
 	} else if (option == "meta_xr_features/hand_tracking") {
-		if (!openxr_enabled && (bool)project_settings->get_setting_with_override("xr/openxr/extensions/hand_tracking")) {
+		if (!openxr_enabled && (bool)export_preset->get_project_setting("xr/openxr/extensions/hand_tracking")) {
 			return "\"Hand Tracking\" requires \"XR Mode\" to be \"OpenXR\".\n";
 		}
 	} else if (option == "meta_xr_features/passthrough") {
-		if (!openxr_enabled && (bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/passthrough")) {
+		if (!openxr_enabled && (bool)export_preset->get_project_setting("xr/openxr/extensions/meta/passthrough")) {
 			return "\"Passthrough\" requires \"XR Mode\" to be \"OpenXR\".\n";
 		}
 	} else if (option == "meta_xr_features/render_model") {
-		if (!openxr_enabled && (bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/render_model")) {
+		if (!openxr_enabled && (bool)export_preset->get_project_setting("xr/openxr/extensions/meta/render_model")) {
 			return "\"Render Model\" requires \"XR Mode\" to be \"OpenXR\".\n";
 		}
 	} else if (option == "meta_xr_features/use_experimental_features") {
@@ -286,8 +287,8 @@ String MetaEditorExportPlugin::_get_export_option_warning(const Ref<EditorExport
 			return "\"Instant splash screen\" is only valid when \"XR Mode\" is \"OpenXR\".\n";
 		}
 	} else if (option == "xr_features/enable_meta_plugin") {
-		if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/color_space")) {
-			if ((int)project_settings->get_setting_with_override("xr/openxr/extensions/meta/color_space/starting_color_space") == 0) {
+		if ((bool)export_preset->get_project_setting("xr/openxr/extensions/meta/color_space")) {
+			if ((int)export_preset->get_project_setting("xr/openxr/extensions/meta/color_space/starting_color_space") == 0) {
 				return "\"Recommended color space is REC709, this can be updated in OpenXR project settings.\"";
 			}
 		}
@@ -297,18 +298,20 @@ String MetaEditorExportPlugin::_get_export_option_warning(const Ref<EditorExport
 }
 
 bool MetaEditorExportPlugin::_get_export_option_visibility(const Ref<EditorExportPlatform> &p_platform, const String &p_option) const {
+	Ref<EditorExportPreset> export_preset = get_export_preset();
+
 	if (p_option == "meta_xr_features/eye_tracking") {
-		return (bool)ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/eye_gaze_interaction");
+		return (bool)export_preset->get_project_setting("xr/openxr/extensions/eye_gaze_interaction");
 	} else if (p_option == "meta_xr_features/face_tracking") {
-		return (bool)ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/meta/face_tracking");
+		return (bool)export_preset->get_project_setting("xr/openxr/extensions/meta/face_tracking");
 	} else if (p_option == "meta_xr_features/body_tracking") {
-		return (bool)ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/meta/body_tracking");
+		return (bool)export_preset->get_project_setting("xr/openxr/extensions/meta/body_tracking");
 	} else if (p_option == "meta_xr_features/hand_tracking" || p_option == "meta_xr_features/hand_tracking_frequency") {
-		return (bool)ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/hand_tracking");
+		return (bool)export_preset->get_project_setting("xr/openxr/extensions/hand_tracking");
 	} else if (p_option == "meta_xr_features/passthrough") {
-		return (bool)ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/meta/passthrough");
+		return (bool)export_preset->get_project_setting("xr/openxr/extensions/meta/passthrough");
 	} else if (p_option == "meta_xr_features/render_model") {
-		return (bool)ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/meta/render_model");
+		return (bool)export_preset->get_project_setting("xr/openxr/extensions/meta/render_model");
 	}
 
 	return true;
@@ -333,10 +336,10 @@ String MetaEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 		return contents;
 	}
 
-	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	Ref<EditorExportPreset> export_preset = get_export_preset();
 
 	// Check for eye tracking
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/eye_gaze_interaction")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/eye_gaze_interaction")) {
 		contents += "    <uses-permission android:name=\"com.oculus.permission.EYE_TRACKING\" />\n";
 
 		int eye_tracking_value = _get_int_option("meta_xr_features/eye_tracking", EYE_TRACKING_OPTIONAL_VALUE);
@@ -348,7 +351,7 @@ String MetaEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 	}
 
 	// Check for face tracking
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/face_tracking")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/meta/face_tracking")) {
 		contents += "    <uses-permission android:name=\"com.oculus.permission.FACE_TRACKING\" />\n";
 
 		int face_tracking_value = _get_int_option("meta_xr_features/face_tracking", FACE_TRACKING_OPTIONAL_VALUE);
@@ -360,7 +363,7 @@ String MetaEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 	}
 
 	// Check for body tracking
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/body_tracking")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/meta/body_tracking")) {
 		contents += "    <uses-permission android:name=\"com.oculus.permission.BODY_TRACKING\" />\n";
 
 		int body_tracking_value = _get_int_option("meta_xr_features/body_tracking", BODY_TRACKING_OPTIONAL_VALUE);
@@ -372,7 +375,7 @@ String MetaEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 	}
 
 	// Check for hand tracking
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/hand_tracking")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/hand_tracking")) {
 		contents += "    <uses-permission android:name=\"com.oculus.permission.HAND_TRACKING\" />\n";
 
 		int hand_tracking_value = _get_int_option("meta_xr_features/hand_tracking", HAND_TRACKING_OPTIONAL_VALUE);
@@ -384,7 +387,7 @@ String MetaEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 	}
 
 	// Check for passthrough
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/passthrough")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/meta/passthrough")) {
 		int passthrough_mode = _get_int_option("meta_xr_features/passthrough", PASSTHROUGH_OPTIONAL_VALUE);
 		if (passthrough_mode == PASSTHROUGH_REQUIRED_VALUE) {
 			contents += "    <uses-feature tools:node=\"replace\" android:name=\"com.oculus.feature.PASSTHROUGH\" android:required=\"true\" />\n";
@@ -394,7 +397,7 @@ String MetaEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 	}
 
 	// Check for render model
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/render_model")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/meta/render_model")) {
 		contents += "    <uses-permission android:name=\"com.oculus.permission.RENDER_MODEL\" />\n";
 
 		int render_model_value = _get_int_option("meta_xr_features/render_model", RENDER_MODEL_OPTIONAL_VALUE);
@@ -406,38 +409,38 @@ String MetaEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 	}
 
 	// Check for EXT spatial entities, or the Meta anchor or scene APIs.
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/spatial_entity/enabled") ||
-			(bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/scene_api") ||
-			(bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/anchor_api")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/spatial_entity/enabled") ||
+			(bool)export_preset->get_project_setting("xr/openxr/extensions/meta/scene_api") ||
+			(bool)export_preset->get_project_setting("xr/openxr/extensions/meta/anchor_api")) {
 		contents += "    <uses-permission android:name=\"com.oculus.permission.USE_ANCHOR_API\" />\n";
 	}
 
 	// Check for anchor sharing
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/anchor_sharing")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/meta/anchor_sharing")) {
 		contents += "    <uses-permission android:name=\"com.oculus.permission.IMPORT_EXPORT_IOT_MAP_DATA\" />\n";
 	}
 
 	// Check for scene api or environment depth
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/spatial_entity/enabled") ||
-			(bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/scene_api") ||
-			(bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/environment_depth")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/spatial_entity/enabled") ||
+			(bool)export_preset->get_project_setting("xr/openxr/extensions/meta/scene_api") ||
+			(bool)export_preset->get_project_setting("xr/openxr/extensions/meta/environment_depth")) {
 		contents += "    <uses-permission android:name=\"com.oculus.permission.USE_SCENE\" />\n";
 	}
 
 	// Check for colocation discovery
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/colocation_discovery")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/meta/colocation_discovery")) {
 		contents += "    <uses-permission android:name=\"com.oculus.permission.USE_COLOCATION_DISCOVERY_API\" />\n";
 	}
 
 // @todo GH Issue 304: Remove check for meta headers when feature becomes part of OpenXR spec.
 #ifdef META_HEADERS_ENABLED
 	// Check for boundary visibility
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/boundary_visibility")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/meta/boundary_visibility")) {
 		contents += "    <uses-permission android:name=\"com.oculus.permission.BOUNDARY_VISIBILITY\" />\n";
 	}
 
 	// Check for stationary reference space
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/stationary_reference_space")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/stationary_reference_space")) {
 		contents += "    <uses-feature android:name=\"com.oculus.experimental.enabled\" />\n";
 	}
 #endif // META_HEADERS_ENABLED
@@ -477,7 +480,7 @@ void MetaEditorExportPlugin::_export_begin(const PackedStringArray &p_features, 
 		return;
 	}
 
-	String boot_splash_path = ProjectSettings::get_singleton()->get_setting_with_override("application/boot_splash/image");
+	String boot_splash_path = get_export_preset()->get_project_setting("application/boot_splash/image");
 	if (!FileAccess::file_exists(boot_splash_path)) {
 		return;
 	}
@@ -492,12 +495,12 @@ String MetaEditorExportPlugin::_get_android_manifest_application_element_content
 		return contents;
 	}
 
-	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	Ref<EditorExportPreset> export_preset = get_export_preset();
 
 	const String supported_devices = String("|").join(_get_supported_devices());
 	contents += "        <meta-data tools:node=\"replace\" android:name=\"com.oculus.supportedDevices\" android:value=\"" + supported_devices + "\" />\n";
 
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/hand_tracking")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/hand_tracking")) {
 		int hand_tracking_frequency = _get_int_option("meta_xr_features/hand_tracking_frequency", HAND_TRACKING_FREQUENCY_LOW_VALUE);
 		const String hand_tracking_frequency_label = (hand_tracking_frequency == HAND_TRACKING_FREQUENCY_LOW_VALUE) ? "LOW" : "HIGH";
 		contents += "        <meta-data tools:node=\"replace\" android:name=\"com.oculus.handtracking.frequency\" android:value=\"" + hand_tracking_frequency_label + "\" />\n";
@@ -514,7 +517,7 @@ String MetaEditorExportPlugin::_get_android_manifest_application_element_content
 		contents += "        <meta-data android:name=\"com.oculus.ossplash.colorspace\" android:value=\"Rec.709\"/>\n";
 	}
 
-	if ((int)project_settings->get_setting_with_override("xr/openxr/environment_blend_mode") != XRInterface::XR_ENV_BLEND_MODE_OPAQUE) {
+	if ((int)export_preset->get_project_setting("xr/openxr/environment_blend_mode") != XRInterface::XR_ENV_BLEND_MODE_OPAQUE) {
 		// Show the splash screen in passthrough, if the user launches it from passthrough.
 		contents += "        <meta-data android:name=\"com.oculus.ossplash.background\" android:value=\"passthrough-contextual\" />\n";
 	}
@@ -543,8 +546,8 @@ String MetaEditorExportPlugin::_get_android_manifest_application_element_content
 		</activity>
 )",
 				_bool_to_string(_get_bool_option("package/exclude_from_recents")),
-				_get_android_orientation_label((DisplayServer::ScreenOrientation)(int)project_settings->get_setting_with_override("display/window/handheld/orientation")),
-				_bool_to_string(project_settings->get_setting_with_override("display/window/size/resizable")));
+				_get_android_orientation_label((DisplayServer::ScreenOrientation)(int)export_preset->get_project_setting("display/window/handheld/orientation")),
+				_bool_to_string(export_preset->get_project_setting("display/window/size/resizable")));
 
 		if (hybrid_launch_mode == OpenXRHybridApp::HYBRID_MODE_PANEL) {
 			contents += R"(

--- a/plugin/src/main/cpp/export/pico_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/pico_export_plugin.cpp
@@ -29,6 +29,7 @@
 
 #include "export/pico_export_plugin.h"
 
+#include <godot_cpp/classes/editor_export_preset.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
 
 using namespace godot;
@@ -93,7 +94,7 @@ String PicoEditorExportPlugin::_get_export_option_warning(const Ref<EditorExport
 			return "\"Hybrid face tracking\" requires \"Record Audio\" to be checked.\n";
 		}
 	} else if (option == "pico_xr_features/hand_tracking") {
-		if (!openxr_enabled && (bool)ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/hand_tracking")) {
+		if (!openxr_enabled && (bool)get_export_preset()->get_project_setting("xr/openxr/extensions/hand_tracking")) {
 			return "\"Hand tracking\" requires \"XR Mode\" to be \"OpenXR\".\n";
 		}
 	}
@@ -103,7 +104,7 @@ String PicoEditorExportPlugin::_get_export_option_warning(const Ref<EditorExport
 
 bool PicoEditorExportPlugin::_get_export_option_visibility(const Ref<EditorExportPlatform> &p_platform, const String &p_option) const {
 	if (p_option == "pico_xr_features/hand_tracking") {
-		return (bool)ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/hand_tracking");
+		return (bool)get_export_preset()->get_project_setting("xr/openxr/extensions/hand_tracking");
 	}
 
 	return true;
@@ -128,10 +129,10 @@ String PicoEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 		return contents;
 	}
 
-	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	Ref<EditorExportPreset> export_preset = get_export_preset();
 
 	// Check for eye tracking
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/eye_gaze_interaction")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/eye_gaze_interaction")) {
 		contents += "    <uses-permission android:name=\"com.picovr.permission.EYE_TRACKING\" />\n";
 	}
 
@@ -142,7 +143,7 @@ String PicoEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 	}
 
 	// Check for spatial entities
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/spatial_entity/enabled")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/spatial_entity/enabled")) {
 		contents += "    <uses-permission android:name=\"com.picovr.permission.SPATIAL_DATA\" />\n";
 	}
 
@@ -155,10 +156,10 @@ String PicoEditorExportPlugin::_get_android_manifest_application_element_content
 		return contents;
 	}
 
-	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	Ref<EditorExportPreset> export_preset = get_export_preset();
 
 	// Check for eye tracking
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/eye_gaze_interaction")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/eye_gaze_interaction")) {
 		contents += "        <meta-data tools:node=\"replace\" android:name=\"picovr.software.eye_tracking\" android:value=\"1\" />\n";
 	}
 
@@ -169,7 +170,7 @@ String PicoEditorExportPlugin::_get_android_manifest_application_element_content
 	}
 
 	//Hand tracking
-	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/hand_tracking")) {
+	if ((bool)export_preset->get_project_setting("xr/openxr/extensions/hand_tracking")) {
 		contents += "        <meta-data tools:node=\"replace\" android:name=\"handtracking\" android:value=\"1\" />\n";
 
 		int hand_tracking = _get_int_option("pico_xr_features/hand_tracking", HAND_TRACKING_LOWFREQUENCY_VALUE);

--- a/plugin/src/main/cpp/export/validation_layers_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/validation_layers_export_plugin.cpp
@@ -32,7 +32,7 @@
 
 #include <openxr/openxr.h>
 #include <godot_cpp/classes/editor_export_platform_android.hpp>
-#include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/editor_export_preset.hpp>
 
 OpenXRValidationLayersEditorExportPlugin::OpenXRValidationLayersEditorExportPlugin() {
 	{
@@ -62,11 +62,11 @@ String OpenXRValidationLayersEditorExportPlugin::_get_export_option_warning(cons
 		return "";
 	}
 
-	ProjectSettings *project_settings = ProjectSettings::get_singleton();
-	ERR_FAIL_NULL_V(project_settings, "");
+	Ref<EditorExportPreset> export_preset = get_export_preset();
+	ERR_FAIL_COND_V(export_preset.is_null(), "");
 
 	if (option == "xr_features/enable_openxr_validation_layers") {
-		int debug_utils_level = project_settings->get_setting("xr/openxr/extensions/debug_utils");
+		int debug_utils_level = export_preset->get_project_setting("xr/openxr/extensions/debug_utils");
 		if ((bool)get_option(option) && debug_utils_level < 2) {
 			return "Set XR -> OpenXR -> Extensions -> Debug Utils to \"Warning\" or higher in Project Settings for OpenXR validation messages to appear in Godot.";
 		}

--- a/thirdparty/godot_cpp_build_profile/build_profile.json
+++ b/thirdparty/godot_cpp_build_profile/build_profile.json
@@ -18,6 +18,7 @@
         "EditorExportPlatform",
         "EditorExportPlatformAndroid",
         "EditorExportPlugin",
+        "EditorExportPreset",
         "EditorFileSystem",
         "EditorInterface",
         "EditorPlugin",


### PR DESCRIPTION
This switches to using `EditorExportPreset::get_project_setting()` rather than `ProjectSettings::get_setting_with_override()` in export plugins, so that it takes into account settings that are using feature tags that are specific to the export preset.

This way, it'll correctly see settings like `flip_y.androidxr` as enabled on the Android XR preset, even if `flip_y` (with no feature tag) is disabled.

**AI Disclosure:** I did the changes to `android_xr_export_plugin.cpp` by hand and also did manual testing to make sure everything still worked as expected (the warnings, option visibility and even `AndroidManifest.xml` changes). However, I then asked Claude Code to make the same changes to all the other `*_export_plugin.cpp` classes based on my diff. I've reviewed (and fixed) the result and I believe this counts as "menial" and similar to "find and replace" per [the 2nd bullet point on this blog post](https://godotengine.org/article/contribution-policy-2026/).