### PR TITLE
Improve AndroidXR extension initialization

### DIFF
--- a/plugin/src/main/cpp/extensions/openxr_android_device_anchor_persistence_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_device_anchor_persistence_extension.cpp
@@ -72,10 +72,14 @@ Dictionary OpenXRAndroidDeviceAnchorPersistenceExtension::_get_requested_extensi
 }
 
 uint64_t OpenXRAndroidDeviceAnchorPersistenceExtension::_set_system_properties_and_get_next_pointer(void *p_next_pointer) {
-	anchor_persistence_properties.type = XR_TYPE_SYSTEM_DEVICE_ANCHOR_PERSISTENCE_PROPERTIES_ANDROID;
-	anchor_persistence_properties.next = p_next_pointer;
-	anchor_persistence_properties.supportsAnchorPersistence = XR_FALSE;
-	return reinterpret_cast<uint64_t>(&anchor_persistence_properties);
+	if (available) {
+		anchor_persistence_properties.type = XR_TYPE_SYSTEM_DEVICE_ANCHOR_PERSISTENCE_PROPERTIES_ANDROID;
+		anchor_persistence_properties.next = p_next_pointer;
+		anchor_persistence_properties.supportsAnchorPersistence = XR_FALSE;
+		return reinterpret_cast<uint64_t>(&anchor_persistence_properties);
+	}
+
+	return reinterpret_cast<uint64_t>(p_next_pointer);
 }
 
 void OpenXRAndroidDeviceAnchorPersistenceExtension::_on_instance_created(uint64_t p_instance) {
@@ -158,6 +162,14 @@ void OpenXRAndroidDeviceAnchorPersistenceExtension::_on_state_focused() {
 		return;
 	}
 
+	OS *os = OS::get_singleton();
+	ERR_FAIL_NULL(os);
+
+	if (os->get_name() != "Android") {
+		available = true;
+		return;
+	}
+
 	// always check for permissions for every focused event, since this is possible:
 	// 1: the app launched, but required permissions are not available
 	// 2: the user opens Android settings app and enables the permission (pauses this app)
@@ -170,9 +182,6 @@ void OpenXRAndroidDeviceAnchorPersistenceExtension::_on_state_focused() {
 
 	// assume unavailable until the permission is granted
 	available = false;
-
-	OS *os = OS::get_singleton();
-	ERR_FAIL_NULL(os);
 
 	PackedStringArray granted_permissions = os->get_granted_permissions();
 	available = granted_permissions.has("android.permission.SCENE_UNDERSTANDING_COARSE") || granted_permissions.has("android.permission.SCENE_UNDERSTANDING_FINE");

--- a/plugin/src/main/cpp/extensions/openxr_android_eye_tracking_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_eye_tracking_extension.cpp
@@ -105,10 +105,12 @@ void OpenXRAndroidEyeTrackingExtension::_on_state_focused() {
 	OS *os = OS::get_singleton();
 	ERR_FAIL_NULL(os);
 
-	PackedStringArray granted_permissions = os->get_granted_permissions();
-	if (!granted_permissions.has("android.permission.EYE_TRACKING_COARSE") && !granted_permissions.has("android.permission.EYE_TRACKING_FINE")) {
-		WARN_PRINT("OpenXR: XR_ANDROID_eye_tracking requires android.permission.EYE_TRACKING_COARSE or android.permission.EYE_TRACKING_FINE; waiting for it to be granted before enabling");
-		return;
+	if (os->get_name() == "Android") {
+		PackedStringArray granted_permissions = os->get_granted_permissions();
+		if (!granted_permissions.has("android.permission.EYE_TRACKING_COARSE") && !granted_permissions.has("android.permission.EYE_TRACKING_FINE")) {
+			WARN_PRINT("OpenXR: XR_ANDROID_eye_tracking requires android.permission.EYE_TRACKING_COARSE or android.permission.EYE_TRACKING_FINE; waiting for it to be granted before enabling");
+			return;
+		}
 	}
 
 	XrEyeTrackerCreateInfoANDROID create_info{

--- a/plugin/src/main/cpp/extensions/openxr_android_face_tracking_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_face_tracking_extension.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  openxr_android_face_tracking_extension_wrapper.cpp                    */
+/*  openxr_android_face_tracking_extension.cpp                            */
 /**************************************************************************/
 /*                       This file is part of:                            */
 /*                              GODOT XR                                  */
@@ -72,16 +72,22 @@ Dictionary OpenXRAndroidFaceTrackingExtension::_get_requested_extensions(uint64_
 }
 
 uint64_t OpenXRAndroidFaceTrackingExtension::_set_system_properties_and_get_next_pointer(void *p_next_pointer) {
-	face_tracking_properties.type = XR_TYPE_SYSTEM_FACE_TRACKING_PROPERTIES_ANDROID;
-	face_tracking_properties.next = p_next_pointer;
-	face_tracking_properties.supportsFaceTracking = XR_FALSE;
-	return reinterpret_cast<uint64_t>(&face_tracking_properties);
+	if (available) {
+		face_tracking_properties.type = XR_TYPE_SYSTEM_FACE_TRACKING_PROPERTIES_ANDROID;
+		face_tracking_properties.next = p_next_pointer;
+		face_tracking_properties.supportsFaceTracking = XR_FALSE;
+		return reinterpret_cast<uint64_t>(&face_tracking_properties);
+	}
+
+	return reinterpret_cast<uint64_t>(p_next_pointer);
 }
 
 void OpenXRAndroidFaceTrackingExtension::_on_instance_created(uint64_t p_instance) {
-	if (!_initialize_openxr_android_face_tracking_extension()) {
-		UtilityFunctions::print("Failed to initialize face tracking extension");
-		available = false;
+	if (available) {
+		if (!_initialize_openxr_android_face_tracking_extension()) {
+			UtilityFunctions::print("Failed to initialize face tracking extension");
+			available = false;
+		}
 	}
 }
 
@@ -101,10 +107,12 @@ void OpenXRAndroidFaceTrackingExtension::_on_state_focused() {
 	OS *os = OS::get_singleton();
 	ERR_FAIL_NULL(os);
 
-	PackedStringArray granted_permissions = os->get_granted_permissions();
-	if (!granted_permissions.has("android.permission.FACE_TRACKING")) {
-		WARN_PRINT("OpenXR: XR_ANDROID_face_tracking requires android.permission.FACE_TRACKING; waiting for it to be granted before enabling");
-		return;
+	if (os->get_name() == "Android") {
+		PackedStringArray granted_permissions = os->get_granted_permissions();
+		if (!granted_permissions.has("android.permission.FACE_TRACKING")) {
+			WARN_PRINT("OpenXR: XR_ANDROID_face_tracking requires android.permission.FACE_TRACKING; waiting for it to be granted before enabling");
+			return;
+		}
 	}
 
 	XrFaceTrackerCreateInfoANDROID create_info{

--- a/plugin/src/main/cpp/extensions/openxr_android_raycast_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_raycast_extension.cpp
@@ -173,6 +173,14 @@ void OpenXRAndroidRaycastExtension::_on_state_focused() {
 		return;
 	}
 
+	OS *os = OS::get_singleton();
+	ERR_FAIL_NULL(os);
+
+	if (os->get_name() != "Android") {
+		available = true;
+		return;
+	}
+
 	// always check for permissions for every focused event, since this is possible:
 	// 1: the app launched, but required permissions are not available
 	// 2: the user opens Android settings app and enables the permission (pauses this app)
@@ -186,9 +194,6 @@ void OpenXRAndroidRaycastExtension::_on_state_focused() {
 
 	// assume unavailable until the permission is granted
 	available = false;
-
-	OS *os = OS::get_singleton();
-	ERR_FAIL_NULL(os);
 
 	PackedStringArray granted_permissions = os->get_granted_permissions();
 	available = granted_permissions.has("android.permission.SCENE_UNDERSTANDING_FINE");

--- a/plugin/src/main/cpp/extensions/openxr_android_trackables_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_trackables_extension.cpp
@@ -115,6 +115,10 @@ void OpenXRAndroidTrackablesExtension::_on_instance_created(uint64_t p_instance)
 }
 
 void OpenXRAndroidTrackablesExtension::_on_session_created(uint64_t p_session_instance) {
+	if (!available) {
+		return;
+	}
+
 	{
 		uint32_t trackable_type_count_output = 0;
 		XrInstance xr_instance = (XrInstance)get_openxr_api()->get_instance();
@@ -211,6 +215,14 @@ void OpenXRAndroidTrackablesExtension::_on_state_focused() {
 		return;
 	}
 
+	OS *os = OS::get_singleton();
+	ERR_FAIL_NULL(os);
+
+	if (os->get_name() != "Android") {
+		available = true;
+		return;
+	}
+
 	// always check for permissions for every focused event, since this is possible:
 	// 1: the app launched, but required permissions are not available
 	// 2: the user opens Android settings app and enables the permission (pauses this app)
@@ -224,9 +236,6 @@ void OpenXRAndroidTrackablesExtension::_on_state_focused() {
 
 	// assume unavailable until the permission is granted
 	available = false;
-
-	OS *os = OS::get_singleton();
-	ERR_FAIL_NULL(os);
 
 	PackedStringArray granted_permissions = os->get_granted_permissions();
 	available = granted_permissions.has("android.permission.SCENE_UNDERSTANDING_COARSE") || granted_permissions.has("android.permission.SCENE_UNDERSTANDING_FINE");
@@ -344,6 +353,10 @@ void OpenXRAndroidTrackablesExtension::find_and_update_all_trackers(XrTrackableT
 
 		if (trackable_count_output != xrtrackables.size()) {
 			WARN_PRINT("OpenXR: trackable query count differs from actual query");
+			if (xrtrackables.size() > trackable_count_output) {
+				// The whole vector is not populated. Resize down to populated size.
+				xrtrackables.resize(trackable_count_output);
+			}
 		}
 
 		for (XrTrackableANDROID xrtrackable : xrtrackables) {

--- a/plugin/src/main/cpp/extensions/openxr_android_trackables_object_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_trackables_object_extension.cpp
@@ -103,6 +103,14 @@ void OpenXRAndroidTrackablesObjectExtension::_on_state_focused() {
 		return;
 	}
 
+	OS *os = OS::get_singleton();
+	ERR_FAIL_NULL(os);
+
+	if (os->get_name() != "Android") {
+		available = true;
+		return;
+	}
+
 	// always check for permissions for every focused event, since this is possible:
 	// 1: the app launched, but required permissions are not available
 	// 2: the user opens Android settings app and enables the permission (pauses this app)
@@ -116,9 +124,6 @@ void OpenXRAndroidTrackablesObjectExtension::_on_state_focused() {
 
 	// assume unavailable until the permission is granted
 	available = false;
-
-	OS *os = OS::get_singleton();
-	ERR_FAIL_NULL(os);
 
 	PackedStringArray granted_permissions = os->get_granted_permissions();
 	available = granted_permissions.has("android.permission.SCENE_UNDERSTANDING_COARSE") || granted_permissions.has("android.permission.SCENE_UNDERSTANDING_FINE");


### PR DESCRIPTION
1. Add missed availability checks during extension initialization.
2. Check permissions only on Android platforms.
3. Misc fix to avoid accessing uninitialized data after error.