### PR TITLE
Add permission check for XR_ANDROID_light_estimation

### DIFF
--- a/plugin/src/main/cpp/classes/openxr_android_light_estimation.cpp
+++ b/plugin/src/main/cpp/classes/openxr_android_light_estimation.cpp
@@ -149,7 +149,7 @@ void OpenXRAndroidLightEstimation::_notification(int p_what) {
 			if (xr_server) {
 				Ref<OpenXRInterface> openxr_interface = xr_server->find_interface("OpenXR");
 				if (openxr_interface.is_valid()) {
-					openxr_interface->connect("session_begun", callable_mp(this, &OpenXRAndroidLightEstimation::start_or_stop));
+					openxr_interface->connect("session_focussed", callable_mp(this, &OpenXRAndroidLightEstimation::start_or_stop));
 				}
 			}
 		} break;
@@ -159,7 +159,7 @@ void OpenXRAndroidLightEstimation::_notification(int p_what) {
 			if (xr_server) {
 				Ref<OpenXRInterface> openxr_interface = xr_server->find_interface("OpenXR");
 				if (openxr_interface.is_valid()) {
-					openxr_interface->disconnect("session_begun", callable_mp(this, &OpenXRAndroidLightEstimation::start_or_stop));
+					openxr_interface->disconnect("session_focussed", callable_mp(this, &OpenXRAndroidLightEstimation::start_or_stop));
 				}
 			}
 		} break;

--- a/plugin/src/main/cpp/extensions/openxr_android_light_estimation_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_light_estimation_extension.cpp
@@ -30,6 +30,7 @@
 #include "extensions/openxr_android_light_estimation_extension.h"
 
 #include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
 using namespace godot;
@@ -103,6 +104,37 @@ void OpenXRAndroidLightEstimationExtension::_on_instance_created(uint64_t instan
 	}
 }
 
+void OpenXRAndroidLightEstimationExtension::_on_state_focused() {
+	if (!is_light_estimation_supported()) {
+		return;
+	}
+
+	OS *os = OS::get_singleton();
+	ERR_FAIL_NULL(os);
+
+	if (os->get_name() != "Android") {
+		permissions_granted = true;
+		return;
+	}
+
+	// always check for permissions for every focused event, since this is possible:
+	// 1: the app launched, but required permissions are not available
+	// 2: the user opens Android settings app and enables the permission (pauses this app)
+	// 3: the user switches back to this app (resumes and focuses this app)
+	//
+	// NOTE: the MainLoop's "on_request_permissions_result" signal is not always called, which is why
+	//       we are always checking here.
+	// NOTE: depending on the app's manifest, it may be restarted if permissions are removed or
+	//       enabled
+
+	PackedStringArray granted_permissions = os->get_granted_permissions();
+	permissions_granted = granted_permissions.has("android.permission.SCENE_UNDERSTANDING_COARSE");
+
+	if (!permissions_granted) {
+		WARN_PRINT("OpenXR: XR_ANDROID_light_estimation requires android.permission.SCENE_UNDERSTANDING_COARSE; waiting for it to be granted");
+	}
+}
+
 void OpenXRAndroidLightEstimationExtension::_on_instance_destroyed() {
 	cleanup();
 }
@@ -139,7 +171,11 @@ Dictionary OpenXRAndroidLightEstimationExtension::_get_requested_extensions(uint
 bool OpenXRAndroidLightEstimationExtension::start_light_estimation() {
 	ERR_FAIL_COND_V(!is_light_estimation_supported(), false);
 
-	if (light_estimator != XR_NULL_HANDLE) {
+	if (!permissions_granted) {
+		return false;
+	}
+
+	if (is_light_estimation_started()) {
 		return true;
 	}
 
@@ -159,7 +195,7 @@ bool OpenXRAndroidLightEstimationExtension::start_light_estimation() {
 }
 
 void OpenXRAndroidLightEstimationExtension::stop_light_estimation() {
-	if (light_estimator == XR_NULL_HANDLE) {
+	if (!is_light_estimation_started()) {
 		return;
 	}
 

--- a/plugin/src/main/cpp/include/extensions/openxr_android_light_estimation_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_android_light_estimation_extension.h
@@ -46,6 +46,7 @@ public:
 	godot::Dictionary _get_requested_extensions(uint64_t p_xr_version) override;
 
 	void _on_instance_created(uint64_t instance) override;
+	void _on_state_focused() override;
 	void _on_instance_destroyed() override;
 
 	uint64_t _set_system_properties_and_get_next_pointer(void *p_next_pointer) override;
@@ -120,6 +121,7 @@ private:
 
 	HashMap<String, bool *> request_extensions;
 	bool android_light_estimation_ext = false;
+	bool permissions_granted = false;
 
 	BitField<LightEstimateType> estimate_types = 0;
 	XrLightEstimatorANDROID light_estimator = XR_NULL_HANDLE;

--- a/samples/androidxr-light-estimation-sample/main.gd
+++ b/samples/androidxr-light-estimation-sample/main.gd
@@ -33,12 +33,10 @@ const SH_FACTORS = [
 
 
 func _ready() -> void:
-	get_tree().on_request_permissions_result.connect(_on_request_permissions_result)
-
 	OS.request_permissions()
 
 	openxr_interface = XRServer.find_interface("OpenXR")
-	openxr_interface.session_begun.connect(_on_openxr_session_begun)
+	openxr_interface.session_focussed.connect(_on_openxr_session_focused)
 
 	OpenXRAndroidLightEstimationExtension.light_estimate_types = OpenXRAndroidLightEstimationExtension.LIGHT_ESTIMATE_TYPE_ALL
 
@@ -47,11 +45,7 @@ func _ready() -> void:
 	menu.ambient_light_mode_changed.connect(_on_ambient_light_mode_changed)
 
 
-func _on_openxr_session_begun() -> void:
-	start_light_estimation()
-
-
-func start_light_estimation() -> void:
+func _on_openxr_session_focused() -> void:
 	if not OpenXRAndroidLightEstimationExtension.is_light_estimation_supported():
 		push_error("Light estimation is unsupported")
 		return
@@ -60,11 +54,6 @@ func start_light_estimation() -> void:
 		print("Light estimation started")
 	else:
 		push_error("Unable to start light estimation")
-
-
-func _on_request_permissions_result(p_permission: String, p_granted: bool) -> void:
-	if p_permission == "android.permission.SCENE_UNDERSTANDING_COARSE" and p_granted:
-		start_light_estimation()
 
 
 func _on_directional_light_mode_changed(p_mode: int) -> void:


### PR DESCRIPTION
Add a check for the required permissions for XR_ANDROID_light_estimation.

The pattern this follows is similar to the trackables PRs [like this one](https://github.com/GodotVR/godot_openxr_vendors/blob/master/plugin/src/main/cpp/extensions/openxr_android_trackables_extension.cpp#L209)

Also updated the sample app and the `OpenXRAndroidLightEstimation` node to adjust to the new permission check.