### PR TITLE
Consistent initialization of system properties structs

### DIFF
--- a/plugin/src/main/cpp/extensions/openxr_android_device_anchor_persistence_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_device_anchor_persistence_extension.cpp
@@ -73,9 +73,7 @@ Dictionary OpenXRAndroidDeviceAnchorPersistenceExtension::_get_requested_extensi
 
 uint64_t OpenXRAndroidDeviceAnchorPersistenceExtension::_set_system_properties_and_get_next_pointer(void *p_next_pointer) {
 	if (available) {
-		anchor_persistence_properties.type = XR_TYPE_SYSTEM_DEVICE_ANCHOR_PERSISTENCE_PROPERTIES_ANDROID;
 		anchor_persistence_properties.next = p_next_pointer;
-		anchor_persistence_properties.supportsAnchorPersistence = XR_FALSE;
 		return reinterpret_cast<uint64_t>(&anchor_persistence_properties);
 	}
 

--- a/plugin/src/main/cpp/extensions/openxr_android_eye_tracking_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_eye_tracking_extension.cpp
@@ -71,9 +71,7 @@ Dictionary OpenXRAndroidEyeTrackingExtension::_get_requested_extensions(uint64_t
 
 uint64_t OpenXRAndroidEyeTrackingExtension::_set_system_properties_and_get_next_pointer(void *p_next_pointer) {
 	if (available) {
-		eye_tracking_properties.type = XR_TYPE_SYSTEM_EYE_TRACKING_PROPERTIES_ANDROID;
 		eye_tracking_properties.next = p_next_pointer;
-		eye_tracking_properties.supportsEyeTracking = XR_FALSE;
 		return reinterpret_cast<uint64_t>(&eye_tracking_properties);
 	}
 

--- a/plugin/src/main/cpp/extensions/openxr_android_face_tracking_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_face_tracking_extension.cpp
@@ -73,9 +73,7 @@ Dictionary OpenXRAndroidFaceTrackingExtension::_get_requested_extensions(uint64_
 
 uint64_t OpenXRAndroidFaceTrackingExtension::_set_system_properties_and_get_next_pointer(void *p_next_pointer) {
 	if (available) {
-		face_tracking_properties.type = XR_TYPE_SYSTEM_FACE_TRACKING_PROPERTIES_ANDROID;
 		face_tracking_properties.next = p_next_pointer;
-		face_tracking_properties.supportsFaceTracking = XR_FALSE;
 		return reinterpret_cast<uint64_t>(&face_tracking_properties);
 	}
 

--- a/plugin/src/main/cpp/extensions/openxr_fb_render_model_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_render_model_extension.cpp
@@ -66,9 +66,7 @@ void OpenXRFbRenderModelExtension::cleanup() {
 }
 
 uint64_t OpenXRFbRenderModelExtension::_set_system_properties_and_get_next_pointer(void *next_pointer) {
-	system_render_model_properties.type = XR_TYPE_SYSTEM_RENDER_MODEL_PROPERTIES_FB;
 	system_render_model_properties.next = next_pointer;
-	system_render_model_properties.supportsRenderModelLoading = false;
 	return reinterpret_cast<uint64_t>(&system_render_model_properties);
 }
 

--- a/plugin/src/main/cpp/extensions/openxr_htc_facial_tracking_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_htc_facial_tracking_extension.cpp
@@ -73,10 +73,7 @@ void OpenXRHtcFacialTrackingExtension::cleanup() {
 }
 
 uint64_t OpenXRHtcFacialTrackingExtension::_set_system_properties_and_get_next_pointer(void *next_pointer) {
-	system_facial_tracking_properties.type = XR_TYPE_SYSTEM_FACIAL_TRACKING_PROPERTIES_HTC;
 	system_facial_tracking_properties.next = next_pointer;
-	system_facial_tracking_properties.supportEyeFacialTracking = false;
-	system_facial_tracking_properties.supportLipFacialTracking = false;
 	return reinterpret_cast<uint64_t>(&system_facial_tracking_properties);
 }
 

--- a/plugin/src/main/cpp/include/extensions/openxr_android_device_anchor_persistence_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_android_device_anchor_persistence_extension.h
@@ -97,7 +97,11 @@ private:
 	HashMap<String, bool *> request_extensions;
 	bool available = false;
 	bool check_for_permissions = false;
-	XrSystemDeviceAnchorPersistencePropertiesANDROID anchor_persistence_properties;
+	XrSystemDeviceAnchorPersistencePropertiesANDROID anchor_persistence_properties = {
+		XR_TYPE_SYSTEM_DEVICE_ANCHOR_PERSISTENCE_PROPERTIES_ANDROID, // type
+		nullptr, // next
+		XR_FALSE, // supportsAnchorPersistence
+	};
 	XrDeviceAnchorPersistenceANDROID device_anchor_persistence = XR_NULL_HANDLE;
 	HashSet<XrTrackableTypeANDROID> supported_trackable_types;
 

--- a/plugin/src/main/cpp/include/extensions/openxr_android_eye_tracking_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_android_eye_tracking_extension.h
@@ -86,7 +86,11 @@ private:
 	HashMap<String, bool *> request_extensions;
 	bool available = false;
 
-	XrSystemEyeTrackingPropertiesANDROID eye_tracking_properties;
+	XrSystemEyeTrackingPropertiesANDROID eye_tracking_properties = {
+		XR_TYPE_SYSTEM_EYE_TRACKING_PROPERTIES_ANDROID, // type
+		nullptr, // next
+		XR_FALSE, // supportsEyeTracking
+	};
 	XrEyeTrackerANDROID eye_tracker = XR_NULL_HANDLE;
 
 	Ref<XRControllerTracker> xr_eye_tracker[2];

--- a/plugin/src/main/cpp/include/extensions/openxr_android_face_tracking_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_android_face_tracking_extension.h
@@ -96,7 +96,11 @@ private:
 	HashMap<String, bool *> request_extensions;
 	bool available = false;
 
-	XrSystemFaceTrackingPropertiesANDROID face_tracking_properties;
+	XrSystemFaceTrackingPropertiesANDROID face_tracking_properties = {
+		XR_TYPE_SYSTEM_FACE_TRACKING_PROPERTIES_ANDROID, // type
+		nullptr, // next
+		XR_FALSE, // supportsFaceTracking
+	};
 	XrFaceTrackerANDROID face_tracker = XR_NULL_HANDLE;
 
 	// Godot XRFaceTracker instance.

--- a/plugin/src/main/cpp/include/extensions/openxr_android_scene_meshing_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_android_scene_meshing_extension.h
@@ -82,7 +82,7 @@ private:
 	XrSystemSceneMeshingPropertiesANDROID scene_meshing_properties = {
 		XR_TYPE_SYSTEM_SCENE_MESHING_PROPERTIES_ANDROID, // type
 		nullptr, // next
-		false, // supportsSceneMeshing
+		XR_FALSE, // supportsSceneMeshing
 	};
 
 	EXT_PROTO_XRRESULT_FUNC5(xrEnumerateSupportedSemanticLabelSetsANDROID, (XrInstance), instance, (XrSystemId), systemId, (uint32_t), supportedSemanticLabelSetsInputCapacity, (uint32_t *), supportedSemanticLabelSetsOutputCount, (XrSceneMeshSemanticLabelSetANDROID *), supportedSemanticLabelSets);

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_body_tracking_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_body_tracking_extension.h
@@ -103,7 +103,7 @@ private:
 	XrSystemBodyTrackingPropertiesFB system_body_tracking_properties = {
 		XR_TYPE_SYSTEM_BODY_TRACKING_PROPERTIES_FB, // type
 		nullptr, // next
-		false, // supportsBodyTracking
+		XR_FALSE, // supportsBodyTracking
 	};
 
 	// XR_FB_body_tracking handle.
@@ -119,10 +119,10 @@ public:
 private:
 	bool meta_body_tracking_full_body_ext = false;
 
-	XrSystemPropertiesBodyTrackingFullBodyMETA system_body_tracking_full_body_properties{
+	XrSystemPropertiesBodyTrackingFullBodyMETA system_body_tracking_full_body_properties = {
 		XR_TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_FULL_BODY_META, // type
 		nullptr, // next
-		false, // supportsFullBodyTracking
+		XR_FALSE, // supportsFullBodyTracking
 	};
 
 // @todo GH Issue 304: Remove check for meta headers when feature becomes part of OpenXR spec.
@@ -153,7 +153,7 @@ private:
 	XrSystemPropertiesBodyTrackingFidelityMETA system_body_tracking_fidelity_properties = {
 		XR_TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_FIDELITY_META, // type
 		nullptr, // next
-		false, // supportsBodyTrackingFidelity
+		XR_FALSE, // supportsBodyTrackingFidelity
 	};
 
 	XrBodyTrackingFidelityStatusMETA body_tracking_fidelity_status = {
@@ -193,7 +193,7 @@ private:
 	XrSystemPropertiesBodyTrackingCalibrationMETA system_body_tracking_calibration_properties = {
 		XR_TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_CALIBRATION_META, // type
 		nullptr, // next
-		false, // supportsHeightOverride
+		XR_FALSE, // supportsHeightOverride
 	};
 
 	XrBodyTrackingCalibrationStatusMETA body_tracking_calibration_status = {

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_color_space_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_color_space_extension.h
@@ -110,6 +110,7 @@ private:
 	XrSystemColorSpacePropertiesFB system_color_space_properties = {
 		XR_TYPE_SYSTEM_COLOR_SPACE_PROPERTIES_FB, // type
 		nullptr, // next
+		XR_COLOR_SPACE_UNMANAGED_FB, // colorSpace
 	};
 
 	Vector<XrColorSpaceFB> supported_color_spaces;

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_render_model_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_render_model_extension.h
@@ -105,5 +105,9 @@ private:
 	bool fb_render_model_ext = false;
 	bool paths_fetched = false;
 	bool openxr_session_active = false;
-	XrSystemRenderModelPropertiesFB system_render_model_properties;
+	XrSystemRenderModelPropertiesFB system_render_model_properties = {
+		XR_TYPE_SYSTEM_RENDER_MODEL_PROPERTIES_FB, // type
+		nullptr, // next
+		XR_FALSE, // supportsRenderModelLoading
+	};
 };

--- a/plugin/src/main/cpp/include/extensions/openxr_htc_facial_tracking_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_htc_facial_tracking_extension.h
@@ -93,7 +93,12 @@ private:
 	bool xr_face_tracker_registered = false;
 
 	// OpenXR system properties struct for XR_HTC_facial_tracking.
-	XrSystemFacialTrackingPropertiesHTC system_facial_tracking_properties;
+	XrSystemFacialTrackingPropertiesHTC system_facial_tracking_properties = {
+		XR_TYPE_SYSTEM_FACIAL_TRACKING_PROPERTIES_HTC, // type
+		nullptr, // next
+		XR_FALSE, // supportEyeFacialTracking
+		XR_FALSE, // supportLipFacialTracking
+	};
 
 	// XR_HTC_facial_tracking handle for eye-tracking
 	XrFacialTrackerHTC facial_tracking_eye = XR_NULL_HANDLE;

--- a/plugin/src/main/cpp/include/extensions/openxr_meta_boundary_visibility_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_meta_boundary_visibility_extension.h
@@ -82,7 +82,7 @@ private:
 	XrSystemBoundaryVisibilityPropertiesMETA boundary_visibility_properties = {
 		XR_TYPE_SYSTEM_BOUNDARY_VISIBILITY_PROPERTIES_META, // type
 		nullptr, // next
-		false // supportsBoundaryVisibility
+		XR_FALSE // supportsBoundaryVisibility
 	};
 
 	XrBoundaryVisibilityMETA current_boundary_visibility = XR_BOUNDARY_VISIBILITY_NOT_SUPPRESSED_META;

--- a/plugin/src/main/cpp/include/extensions/openxr_meta_simultaneous_hands_and_controllers_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_meta_simultaneous_hands_and_controllers_extension.h
@@ -81,7 +81,7 @@ private:
 	XrSystemSimultaneousHandsAndControllersPropertiesMETA simultaneous_hands_and_controllers_properties = {
 		XR_TYPE_SYSTEM_SIMULTANEOUS_HANDS_AND_CONTROLLERS_PROPERTIES_META, // type
 		nullptr, // next
-		false // supportsSimultaneousHandsAndControllers
+		XR_FALSE // supportsSimultaneousHandsAndControllers
 	};
 
 	const XrSimultaneousHandsAndControllersTrackingResumeInfoMETA simultaneous_hands_and_controllers_tracking_resume_info = {


### PR DESCRIPTION
This started because I noticed (while reviewing https://github.com/GodotVR/godot_openxr_vendors/pull/510) that we sometimes initialize system properties structs in `_set_system_properties_and_get_next_pointer()` (only 5 times); whereas we usually initialize them in the header (all the other times).

Then I started looking at other inconsistencies in initialization of system properties structs like:

- Using `false` instead of `XR_FALSE` (we're doing this in other places too, but I only addressed system properties structs)
- Missing a field on `XrSystemColorSpacePropertiesFB`

This PR aims to clean up all those inconsistencies!