### PR TITLE
Update permission checks for AndroidXR Trackables

### DIFF
--- a/doc_classes/OpenXRAndroidDeviceAnchorPersistenceExtension.xml
+++ b/doc_classes/OpenXRAndroidDeviceAnchorPersistenceExtension.xml
@@ -10,6 +10,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="are_permissions_granted" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Whether the required Android permissions for this extension are granted or not.
+			</description>
+		</method>
 		<method name="create_persisted_anchor_tracker">
 			<return type="OpenXRAndroidAnchorTracker" />
 			<param index="0" name="uuid" type="StringName" />

--- a/doc_classes/OpenXRAndroidLightEstimation.xml
+++ b/doc_classes/OpenXRAndroidLightEstimation.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="ambient_light_energy_multiplier" type="float" setter="set_ambient_light_energy_multiplier" getter="get_ambient_light_energy_multiplier" default="1.0">
-      The value ambient light energy is multiplied by.
+			The value ambient light energy is multiplied by.
 		</member>
 		<member name="ambient_light_mode" type="int" setter="set_ambient_light_mode" getter="get_ambient_light_mode" enum="OpenXRAndroidLightEstimation.AmbientLightMode" default="1">
 			Controls how ambient light data is applied to the [WorldEnvironment].
@@ -18,9 +18,9 @@
 		<member name="directional_light" type="DirectionalLight3D" setter="set_directional_light" getter="get_directional_light">
 			The [DirectionalLight3D] that the light estimation data is applied to.
 		</member>
-		<member name="directional_light_energy_multiplier" type="float" setter="set_ambient_light_energy_multiplier" getter="get_ambient_light_energy_multiplier" default="1.0">
-      The value directional light energy is multiplied by.
-      Only applied when [member directional_light_mode] is set to [constant DIRECTIONAL_LIGHT_MODE_DIRECTION_INTENSITY] or [constant DIRECTIONAL_LIGHT_MODE_DIRECTION_COLOR_INTENSITY].
+		<member name="directional_light_energy_multiplier" type="float" setter="set_directional_light_energy_multiplier" getter="get_directional_light_energy_multiplier" default="1.0">
+			The value directional light energy is multiplied by.
+			Only applied when [member directional_light_mode] is set to [constant DIRECTIONAL_LIGHT_MODE_DIRECTION_INTENSITY] or [constant DIRECTIONAL_LIGHT_MODE_DIRECTION_COLOR_INTENSITY].
 		</member>
 		<member name="directional_light_mode" type="int" setter="set_directional_light_mode" getter="get_directional_light_mode" enum="OpenXRAndroidLightEstimation.DirectionalLightMode" default="1">
 			Controls how directional light data is applied to the [DirectionalLight3D].

--- a/doc_classes/OpenXRAndroidRaycastExtension.xml
+++ b/doc_classes/OpenXRAndroidRaycastExtension.xml
@@ -10,6 +10,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="are_permissions_granted" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Whether the required Android permissions for this extension are granted or not.
+			</description>
+		</method>
 		<method name="is_raycast_supported" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/doc_classes/OpenXRAndroidTrackablesExtension.xml
+++ b/doc_classes/OpenXRAndroidTrackablesExtension.xml
@@ -9,6 +9,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="are_permissions_granted" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Whether the required Android permissions for this extension are granted or not.
+			</description>
+		</method>
 		<method name="can_create_more_anchors" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/doc_classes/OpenXRAndroidTrackablesObjectExtension.xml
+++ b/doc_classes/OpenXRAndroidTrackablesObjectExtension.xml
@@ -10,6 +10,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="are_permissions_granted" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Whether the required Android permissions for this extension are granted or not.
+			</description>
+		</method>
 		<method name="create_object_context">
 			<return type="RID" />
 			<param index="0" name="object_labels" type="Array" />

--- a/plugin/src/main/cpp/extensions/openxr_android_device_anchor_persistence_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_device_anchor_persistence_extension.cpp
@@ -99,9 +99,7 @@ void OpenXRAndroidDeviceAnchorPersistenceExtension::_on_instance_created(uint64_
 }
 
 void OpenXRAndroidDeviceAnchorPersistenceExtension::_on_session_created(uint64_t p_session_instance) {
-	available = available && XR_TRUE == anchor_persistence_properties.supportsAnchorPersistence;
-
-	if (!available) {
+	if (!is_device_anchor_persistence_supported()) {
 		return;
 	}
 
@@ -150,21 +148,17 @@ void OpenXRAndroidDeviceAnchorPersistenceExtension::_on_session_created(uint64_t
 		supported_trackable_types.insert(trackable_type);
 	}
 
-	// assume unavailable until the permission is granted (see _on_state_focused())
-	available = false;
-	check_for_permissions = true;
+	// wait for _on_state_focused() to correctly set permissions_granted
+	permissions_granted = false;
 }
 
 void OpenXRAndroidDeviceAnchorPersistenceExtension::_on_state_focused() {
-	if (!available && !check_for_permissions) {
+	if (!is_device_anchor_persistence_supported()) {
 		return;
 	}
 
-	OS *os = OS::get_singleton();
-	ERR_FAIL_NULL(os);
-
-	if (os->get_name() != "Android") {
-		available = true;
+	if (!OpenXRUtilities::supports_runtime_permissions()) {
+		permissions_granted = true;
 		return;
 	}
 
@@ -178,19 +172,19 @@ void OpenXRAndroidDeviceAnchorPersistenceExtension::_on_state_focused() {
 	// NOTE: depending on the app's manifest, it may be restarted if permissions are removed or
 	//       enabled
 
-	// assume unavailable until the permission is granted
-	available = false;
+	OS *os = OS::get_singleton();
+	ERR_FAIL_NULL(os);
 
 	PackedStringArray granted_permissions = os->get_granted_permissions();
-	available = granted_permissions.has("android.permission.SCENE_UNDERSTANDING_COARSE") || granted_permissions.has("android.permission.SCENE_UNDERSTANDING_FINE");
+	permissions_granted = granted_permissions.has("android.permission.SCENE_UNDERSTANDING_COARSE") || granted_permissions.has("android.permission.SCENE_UNDERSTANDING_FINE");
 
-	if (!available) {
-		WARN_PRINT("OpenXR: XR_ANDROID_device_anchor_persistence requires android.permission.SCENE_UNDERSTANDING_COARSE or android.permission.SCENE_UNDERSTANDING_FINE; waiting for the permission to be set before enabling");
+	if (!permissions_granted) {
+		WARN_PRINT("OpenXR: XR_ANDROID_device_anchor_persistence requires android.permission.SCENE_UNDERSTANDING_COARSE or android.permission.SCENE_UNDERSTANDING_FINE; waiting for one of them to be granted");
 	}
 }
 
 void OpenXRAndroidDeviceAnchorPersistenceExtension::_on_process() {
-	if (persisted_anchor_discovery_cooldown < 0 || !OpenXRAndroidTrackablesExtension::get_singleton()->can_create_more_anchors()) {
+	if (!permissions_granted || !is_device_anchor_persistence_supported() || persisted_anchor_discovery_cooldown < 0 || !OpenXRAndroidTrackablesExtension::get_singleton()->can_create_more_anchors()) {
 		return;
 	}
 
@@ -249,9 +243,7 @@ bool OpenXRAndroidDeviceAnchorPersistenceExtension::set_restore_persisted_anchor
 }
 
 bool OpenXRAndroidDeviceAnchorPersistenceExtension::restore_persisted_anchor_trackers() {
-	if (!available) {
-		return false;
-	}
+	ERR_FAIL_COND_V(!is_device_anchor_persistence_supported() || !permissions_granted, false);
 
 	OpenXRAndroidTrackablesExtension *trackables_extension = OpenXRAndroidTrackablesExtension::get_singleton();
 	ERR_FAIL_NULL_V(trackables_extension, false);
@@ -318,9 +310,7 @@ TypedArray<StringName> OpenXRAndroidDeviceAnchorPersistenceExtension::get_all_pe
 
 Ref<OpenXRAndroidAnchorTracker> OpenXRAndroidDeviceAnchorPersistenceExtension::create_persisted_anchor_tracker(StringName p_uuid) {
 	Ref<OpenXRAndroidAnchorTracker> ret;
-	if (!available) {
-		return ret;
-	}
+	ERR_FAIL_COND_V(!is_device_anchor_persistence_supported() || !permissions_granted, ret);
 
 	if (!OpenXRAndroidTrackablesExtension::get_singleton()->can_create_more_anchors()) {
 		WARN_PRINT("OpenXR: unable to create persisted anchor tracker");
@@ -371,7 +361,9 @@ bool OpenXRAndroidDeviceAnchorPersistenceExtension::persist_anchor_tracker(Ref<O
 }
 
 bool OpenXRAndroidDeviceAnchorPersistenceExtension::persist_xranchor(Ref<OpenXRAndroidAnchorTracker> p_anchor_tracker, StringName &r_uuid, XrUuidEXT &r_xruuid) {
-	if (!available || p_anchor_tracker.is_null()) {
+	ERR_FAIL_COND_V(!is_device_anchor_persistence_supported(), false);
+
+	if (!permissions_granted || p_anchor_tracker.is_null()) {
 		return false;
 	}
 
@@ -442,9 +434,7 @@ OpenXRAndroidAnchorTracker::PersistState OpenXRAndroidDeviceAnchorPersistenceExt
 
 OpenXRAndroidAnchorTracker::PersistState OpenXRAndroidDeviceAnchorPersistenceExtension::get_xranchor_persist_state(const StringName &p_uuid, const XrUuidEXT &p_xruuid) {
 	OpenXRAndroidAnchorTracker::PersistState ret{ OpenXRAndroidAnchorTracker::PERSIST_STATE_ERROR };
-	if (!available) {
-		return ret;
-	}
+	ERR_FAIL_COND_V(!is_device_anchor_persistence_supported() || !permissions_granted, ret);
 
 	if (p_uuid.is_empty()) {
 		// don't log so callers don't have to check for empty uuid at every call site
@@ -516,7 +506,9 @@ bool OpenXRAndroidDeviceAnchorPersistenceExtension::unpersist_anchor_tracker(Ref
 }
 
 bool OpenXRAndroidDeviceAnchorPersistenceExtension::unpersist_xranchor(const StringName &p_uuid, const XrUuidEXT &p_xruuid) {
-	if (!available || p_uuid.is_empty()) {
+	ERR_FAIL_COND_V(!is_device_anchor_persistence_supported(), false);
+
+	if (!permissions_granted || p_uuid.is_empty()) {
 		// don't log so callers don't have to check for empty uuid at every call site
 		return true;
 	}
@@ -550,7 +542,11 @@ void OpenXRAndroidDeviceAnchorPersistenceExtension::on_xranchor_tracker_destroye
 }
 
 bool OpenXRAndroidDeviceAnchorPersistenceExtension::is_device_anchor_persistence_supported() const {
-	return available;
+	return available && XR_TRUE == anchor_persistence_properties.supportsAnchorPersistence;
+}
+
+bool OpenXRAndroidDeviceAnchorPersistenceExtension::are_permissions_granted() const {
+	return permissions_granted;
 }
 
 void OpenXRAndroidDeviceAnchorPersistenceExtension::_bind_methods() {
@@ -565,6 +561,7 @@ void OpenXRAndroidDeviceAnchorPersistenceExtension::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("unpersist_anchor_tracker", "anchor_tracker"), &OpenXRAndroidDeviceAnchorPersistenceExtension::unpersist_anchor_tracker);
 	ClassDB::bind_method(D_METHOD("unpersist_anchor_uuid", "uuid"), &OpenXRAndroidDeviceAnchorPersistenceExtension::unpersist_anchor_uuid);
 	ClassDB::bind_method(D_METHOD("is_device_anchor_persistence_supported"), &OpenXRAndroidDeviceAnchorPersistenceExtension::is_device_anchor_persistence_supported);
+	ClassDB::bind_method(D_METHOD("are_permissions_granted"), &OpenXRAndroidDeviceAnchorPersistenceExtension::are_permissions_granted);
 }
 
 bool OpenXRAndroidDeviceAnchorPersistenceExtension::_initialize_androidxr_device_persistence_extension() {
@@ -605,9 +602,7 @@ XrSpace OpenXRAndroidDeviceAnchorPersistenceExtension::_create_xrspace_from_pers
 TypedArray<StringName> OpenXRAndroidDeviceAnchorPersistenceExtension::_get_all_persisted_anchors(bool &r_success) {
 	r_success = false;
 	TypedArray<StringName> ret{};
-	if (!available) {
-		return ret;
-	}
+	ERR_FAIL_COND_V(!is_device_anchor_persistence_supported() || !permissions_granted, ret);
 
 	XrDeviceAnchorPersistenceANDROID anchor_persistence = _get_or_create_device_anchor_persistence();
 	if (XR_NULL_HANDLE == anchor_persistence) {
@@ -671,7 +666,6 @@ XrDeviceAnchorPersistenceANDROID OpenXRAndroidDeviceAnchorPersistenceExtension::
 	if (result != XR_SUCCESS || XR_NULL_HANDLE == device_anchor_persistence) {
 		UtilityFunctions::printerr("OpenXR: Failed to create device anchor persistence; ", get_openxr_api()->get_error_string(result));
 		available = false;
-		check_for_permissions = false;
 		device_anchor_persistence = XR_NULL_HANDLE;
 		return XR_NULL_HANDLE;
 	}

--- a/plugin/src/main/cpp/extensions/openxr_android_eye_tracking_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_eye_tracking_extension.cpp
@@ -100,10 +100,10 @@ void OpenXRAndroidEyeTrackingExtension::_on_state_focused() {
 		return;
 	}
 
-	OS *os = OS::get_singleton();
-	ERR_FAIL_NULL(os);
+	if (OpenXRUtilities::supports_runtime_permissions()) {
+		OS *os = OS::get_singleton();
+		ERR_FAIL_NULL(os);
 
-	if (os->get_name() == "Android") {
 		PackedStringArray granted_permissions = os->get_granted_permissions();
 		if (!granted_permissions.has("android.permission.EYE_TRACKING_COARSE") && !granted_permissions.has("android.permission.EYE_TRACKING_FINE")) {
 			WARN_PRINT("OpenXR: XR_ANDROID_eye_tracking requires android.permission.EYE_TRACKING_COARSE or android.permission.EYE_TRACKING_FINE; waiting for it to be granted before enabling");

--- a/plugin/src/main/cpp/extensions/openxr_android_face_tracking_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_face_tracking_extension.cpp
@@ -102,10 +102,10 @@ void OpenXRAndroidFaceTrackingExtension::_on_state_focused() {
 		return;
 	}
 
-	OS *os = OS::get_singleton();
-	ERR_FAIL_NULL(os);
+	if (OpenXRUtilities::supports_runtime_permissions()) {
+		OS *os = OS::get_singleton();
+		ERR_FAIL_NULL(os);
 
-	if (os->get_name() == "Android") {
 		PackedStringArray granted_permissions = os->get_granted_permissions();
 		if (!granted_permissions.has("android.permission.FACE_TRACKING")) {
 			WARN_PRINT("OpenXR: XR_ANDROID_face_tracking requires android.permission.FACE_TRACKING; waiting for it to be granted before enabling");

--- a/plugin/src/main/cpp/extensions/openxr_android_light_estimation_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_light_estimation_extension.cpp
@@ -109,10 +109,7 @@ void OpenXRAndroidLightEstimationExtension::_on_state_focused() {
 		return;
 	}
 
-	OS *os = OS::get_singleton();
-	ERR_FAIL_NULL(os);
-
-	if (os->get_name() != "Android") {
+	if (!OpenXRUtilities::supports_runtime_permissions()) {
 		permissions_granted = true;
 		return;
 	}
@@ -126,6 +123,9 @@ void OpenXRAndroidLightEstimationExtension::_on_state_focused() {
 	//       we are always checking here.
 	// NOTE: depending on the app's manifest, it may be restarted if permissions are removed or
 	//       enabled
+
+	OS *os = OS::get_singleton();
+	ERR_FAIL_NULL(os);
 
 	PackedStringArray granted_permissions = os->get_granted_permissions();
 	permissions_granted = granted_permissions.has("android.permission.SCENE_UNDERSTANDING_COARSE");

--- a/plugin/src/main/cpp/extensions/openxr_android_raycast_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_raycast_extension.cpp
@@ -163,21 +163,17 @@ void OpenXRAndroidRaycastExtension::_on_session_created(uint64_t p_session_insta
 		return;
 	}
 
-	// assume unavailable until the permission is granted (see _on_state_focused())
-	available = false;
-	check_for_permissions = true;
+	// wait for _on_state_focused() to correctly set permissions_granted
+	permissions_granted = false;
 }
 
 void OpenXRAndroidRaycastExtension::_on_state_focused() {
-	if (!available && !check_for_permissions) {
+	if (!is_raycast_supported()) {
 		return;
 	}
 
-	OS *os = OS::get_singleton();
-	ERR_FAIL_NULL(os);
-
-	if (os->get_name() != "Android") {
-		available = true;
+	if (!OpenXRUtilities::supports_runtime_permissions()) {
+		permissions_granted = true;
 		return;
 	}
 
@@ -192,14 +188,14 @@ void OpenXRAndroidRaycastExtension::_on_state_focused() {
 	// NOTE: depending on the app's manifest, it may be restarted if permissions are removed or
 	//       enabled
 
-	// assume unavailable until the permission is granted
-	available = false;
+	OS *os = OS::get_singleton();
+	ERR_FAIL_NULL(os);
 
 	PackedStringArray granted_permissions = os->get_granted_permissions();
-	available = granted_permissions.has("android.permission.SCENE_UNDERSTANDING_FINE");
+	permissions_granted = granted_permissions.has("android.permission.SCENE_UNDERSTANDING_FINE");
 
-	if (!available) {
-		WARN_PRINT("OpenXR: XR_ANDROID_raycast requires android.permission.SCENE_UNDERSTANDING_FINE; waiting for it to be granted before enabling");
+	if (!permissions_granted) {
+		WARN_PRINT("OpenXR: XR_ANDROID_raycast requires android.permission.SCENE_UNDERSTANDING_FINE; waiting for it to be granted");
 	}
 }
 
@@ -213,9 +209,7 @@ void OpenXRAndroidRaycastExtension::_on_session_destroyed() {
 
 TypedArray<OpenXRAndroidHitResult> OpenXRAndroidRaycastExtension::raycast(Array p_trackable_types, const Vector3 &p_origin, const Vector3 &p_trajectory, int p_max_results) {
 	TypedArray<OpenXRAndroidHitResult> ret;
-	if (!available) {
-		return ret;
-	}
+	ERR_FAIL_COND_V(!is_raycast_supported() || !permissions_granted, ret);
 
 	OpenXRAndroidTrackablesExtension *wrapper = OpenXRAndroidTrackablesExtension::get_singleton();
 	ERR_FAIL_NULL_V(wrapper, ret);
@@ -311,9 +305,14 @@ bool OpenXRAndroidRaycastExtension::is_raycast_supported() const {
 	return available;
 }
 
+bool OpenXRAndroidRaycastExtension::are_permissions_granted() const {
+	return permissions_granted;
+}
+
 void OpenXRAndroidRaycastExtension::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("raycast", "trackable_types", "origin", "trajectory", "max_results"), &OpenXRAndroidRaycastExtension::raycast);
 	ClassDB::bind_method(D_METHOD("is_raycast_supported"), &OpenXRAndroidRaycastExtension::is_raycast_supported);
+	ClassDB::bind_method(D_METHOD("are_permissions_granted"), &OpenXRAndroidRaycastExtension::are_permissions_granted);
 	BIND_ENUM_CONSTANT(TRACKABLE_TYPE_PLANE);
 	BIND_ENUM_CONSTANT(TRACKABLE_TYPE_DEPTH);
 }

--- a/plugin/src/main/cpp/extensions/openxr_android_trackables_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_trackables_extension.cpp
@@ -115,11 +115,7 @@ void OpenXRAndroidTrackablesExtension::_on_instance_created(uint64_t p_instance)
 }
 
 void OpenXRAndroidTrackablesExtension::_on_session_created(uint64_t p_session_instance) {
-	if (!available) {
-		return;
-	}
-
-	{
+	if (is_trackables_supported()) {
 		uint32_t trackable_type_count_output = 0;
 		XrInstance xr_instance = (XrInstance)get_openxr_api()->get_instance();
 		XrSystemId xr_system_id = (XrSystemId)get_openxr_api()->get_system_id();
@@ -162,7 +158,7 @@ void OpenXRAndroidTrackablesExtension::_on_session_created(uint64_t p_session_in
 		}
 	}
 
-	{
+	if (is_anchors_supported()) {
 		uint32_t trackable_type_count_output = 0;
 		XrInstance xr_instance = (XrInstance)get_openxr_api()->get_instance();
 		XrSystemId xr_system_id = (XrSystemId)get_openxr_api()->get_system_id();
@@ -205,21 +201,19 @@ void OpenXRAndroidTrackablesExtension::_on_session_created(uint64_t p_session_in
 		}
 	}
 
-	// assume unavailable until the permission is granted (see _on_state_focused())
-	available = false;
-	check_for_permissions = true;
+	// wait for _on_state_focused() to correctly set permissions_granted
+	permissions_granted = false;
 }
 
 void OpenXRAndroidTrackablesExtension::_on_state_focused() {
-	if (!available && !check_for_permissions) {
+	// The permissions are required for both, so still check permissions if at least one of them is
+	// supported
+	if (!is_trackables_supported() && !is_anchors_supported()) {
 		return;
 	}
 
-	OS *os = OS::get_singleton();
-	ERR_FAIL_NULL(os);
-
-	if (os->get_name() != "Android") {
-		available = true;
+	if (!OpenXRUtilities::supports_runtime_permissions()) {
+		permissions_granted = true;
 		return;
 	}
 
@@ -234,19 +228,19 @@ void OpenXRAndroidTrackablesExtension::_on_state_focused() {
 	// NOTE: depending on the app's manifest, it may be restarted if permissions are removed or
 	//       enabled
 
-	// assume unavailable until the permission is granted
-	available = false;
+	OS *os = OS::get_singleton();
+	ERR_FAIL_NULL(os);
 
 	PackedStringArray granted_permissions = os->get_granted_permissions();
-	available = granted_permissions.has("android.permission.SCENE_UNDERSTANDING_COARSE") || granted_permissions.has("android.permission.SCENE_UNDERSTANDING_FINE");
+	permissions_granted = granted_permissions.has("android.permission.SCENE_UNDERSTANDING_COARSE") || granted_permissions.has("android.permission.SCENE_UNDERSTANDING_FINE");
 
-	if (!available) {
-		WARN_PRINT("OpenXR: XR_ANDROID_trackables requires android.permission.SCENE_UNDERSTANDING_COARSE or android.permission.SCENE_UNDERSTANDING_FINE; waiting for one of them to be granted before enabling");
+	if (!permissions_granted) {
+		WARN_PRINT("OpenXR: XR_ANDROID_trackables requires android.permission.SCENE_UNDERSTANDING_COARSE or android.permission.SCENE_UNDERSTANDING_FINE; waiting for either permission to be granted");
 	}
 }
 
 void OpenXRAndroidTrackablesExtension::_on_process() {
-	if (!available) {
+	if (!permissions_granted) {
 		return;
 	}
 
@@ -284,16 +278,10 @@ void OpenXRAndroidTrackablesExtension::set_plane_tracker_discovery_cooldown(int 
 }
 
 void OpenXRAndroidTrackablesExtension::discover_plane_trackers(bool p_update_trackers) {
-	if (!available) {
-		return;
-	}
+	ERR_FAIL_COND(!is_trackables_supported() || !permissions_granted);
 
 	plane_trackable_tracker = get_or_create_plane_xrtrackable_tracker();
-	if (plane_trackable_tracker == XR_NULL_HANDLE) {
-		check_for_permissions = false;
-		available = false;
-		return;
-	}
+	ERR_FAIL_COND(plane_trackable_tracker == XR_NULL_HANDLE);
 
 	find_and_update_all_trackers(plane_trackable_tracker, XR_TRACKABLE_TYPE_PLANE_ANDROID, p_update_trackers, current_plane_trackables);
 }
@@ -397,6 +385,8 @@ void OpenXRAndroidTrackablesExtension::maybe_destroy_trackable_tracker(XrTrackab
 
 Ref<OpenXRAndroidAnchorTracker> OpenXRAndroidTrackablesExtension::create_anchor_tracker(const Transform3D &p_pose, Ref<OpenXRAndroidTrackableTracker> p_tracker) {
 	Ref<OpenXRAndroidAnchorTracker> ret{};
+	ERR_FAIL_COND_V(!is_anchors_supported() || !permissions_granted, ret);
+
 	if (!can_create_more_anchors()) {
 		UtilityFunctions::printerr("OpenXR: Unable to create more anchor trackers");
 		return ret;
@@ -456,6 +446,8 @@ Ref<OpenXRAndroidAnchorTracker> OpenXRAndroidTrackablesExtension::xrcreate_ancho
 }
 
 void OpenXRAndroidTrackablesExtension::destroy_anchor_tracker(Ref<OpenXRAndroidAnchorTracker> p_anchor_tracker) {
+	ERR_FAIL_COND(!is_anchors_supported());
+
 	if (p_anchor_tracker.is_null()) {
 		return;
 	}
@@ -520,6 +512,8 @@ void OpenXRAndroidTrackablesExtension::set_anchor_tracker_update_cooldown(int p_
 }
 
 void OpenXRAndroidTrackablesExtension::update_anchor_trackers() {
+	ERR_FAIL_COND(!is_anchors_supported() || !permissions_granted);
+
 	for (const auto &[xrspace, anchor_tracker] : current_anchor_trackers) {
 		if (anchor_tracker.is_null()) {
 			continue;
@@ -535,6 +529,10 @@ bool OpenXRAndroidTrackablesExtension::can_create_more_anchors() const {
 
 bool OpenXRAndroidTrackablesExtension::is_anchors_supported() const {
 	return is_trackables_supported() && system_trackables_properties.supportsAnchor == XR_TRUE;
+}
+
+bool OpenXRAndroidTrackablesExtension::are_permissions_granted() const {
+	return permissions_granted;
 }
 
 bool OpenXRAndroidTrackablesExtension::is_trackables_supported() const {
@@ -554,6 +552,7 @@ void OpenXRAndroidTrackablesExtension::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("can_create_more_anchors"), &OpenXRAndroidTrackablesExtension::can_create_more_anchors);
 	ClassDB::bind_method(D_METHOD("is_trackables_supported"), &OpenXRAndroidTrackablesExtension::is_trackables_supported);
 	ClassDB::bind_method(D_METHOD("is_anchors_supported"), &OpenXRAndroidTrackablesExtension::is_anchors_supported);
+	ClassDB::bind_method(D_METHOD("are_permissions_granted"), &OpenXRAndroidTrackablesExtension::are_permissions_granted);
 }
 
 bool OpenXRAndroidTrackablesExtension::_initialize_openxr_android_trackables_extension() {
@@ -611,7 +610,7 @@ Ref<OpenXRAndroidTrackableTracker> OpenXRAndroidTrackablesExtension::_get_or_cre
 }
 
 void OpenXRAndroidTrackablesExtension::_on_process_anchors() {
-	if (anchor_update_cooldown < 0) {
+	if (!is_anchors_supported() || anchor_update_cooldown < 0) {
 		return;
 	}
 
@@ -625,7 +624,7 @@ void OpenXRAndroidTrackablesExtension::_on_process_anchors() {
 }
 
 void OpenXRAndroidTrackablesExtension::_on_process_plane_trackers() {
-	if (plane_trackable_discovery_cooldown < 0) {
+	if (!is_trackables_supported() || plane_trackable_discovery_cooldown < 0) {
 		return;
 	}
 

--- a/plugin/src/main/cpp/extensions/openxr_android_trackables_object_extension.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_android_trackables_object_extension.cpp
@@ -93,21 +93,17 @@ void OpenXRAndroidTrackablesObjectExtension::_on_instance_created(uint64_t p_ins
 		return;
 	}
 
-	// assume unavailable until the permission is granted (see _on_state_focused())
-	available = false;
-	check_for_permissions = true;
+	// wait for _on_state_focused() to correctly set permissions_granted
+	permissions_granted = false;
 }
 
 void OpenXRAndroidTrackablesObjectExtension::_on_state_focused() {
-	if (!available && !check_for_permissions) {
+	if (!is_trackables_object_supported()) {
 		return;
 	}
 
-	OS *os = OS::get_singleton();
-	ERR_FAIL_NULL(os);
-
-	if (os->get_name() != "Android") {
-		available = true;
+	if (!OpenXRUtilities::supports_runtime_permissions()) {
+		permissions_granted = true;
 		return;
 	}
 
@@ -122,19 +118,19 @@ void OpenXRAndroidTrackablesObjectExtension::_on_state_focused() {
 	// NOTE: depending on the app's manifest, it may be restarted if permissions are removed or
 	//       enabled
 
-	// assume unavailable until the permission is granted
-	available = false;
+	OS *os = OS::get_singleton();
+	ERR_FAIL_NULL(os);
 
 	PackedStringArray granted_permissions = os->get_granted_permissions();
-	available = granted_permissions.has("android.permission.SCENE_UNDERSTANDING_COARSE") || granted_permissions.has("android.permission.SCENE_UNDERSTANDING_FINE");
+	permissions_granted = granted_permissions.has("android.permission.SCENE_UNDERSTANDING_COARSE") || granted_permissions.has("android.permission.SCENE_UNDERSTANDING_FINE");
 
-	if (!available) {
-		WARN_PRINT("OpenXR: XR_ANDROID_trackables_object requires android.permission.SCENE_UNDERSTANDING_COARSE or android.permission.SCENE_UNDERSTANDING_FINE; waiting for one of them to be granted before enabling");
+	if (!permissions_granted) {
+		WARN_PRINT("OpenXR: XR_ANDROID_trackables_object requires android.permission.SCENE_UNDERSTANDING_COARSE or android.permission.SCENE_UNDERSTANDING_FINE; waiting for one of them to be granted");
 	}
 }
 
 void OpenXRAndroidTrackablesObjectExtension::_on_process() {
-	if (!available || object_trackable_discovery_cooldown < 0) {
+	if (!permissions_granted || !is_trackables_object_supported() || object_trackable_discovery_cooldown < 0) {
 		return;
 	}
 
@@ -167,6 +163,10 @@ bool OpenXRAndroidTrackablesObjectExtension::is_trackables_object_supported() co
 	return available;
 }
 
+bool OpenXRAndroidTrackablesObjectExtension::are_permissions_granted() const {
+	return permissions_granted;
+}
+
 void OpenXRAndroidTrackablesObjectExtension::set_default_object_context_enabled(bool p_enabled) {
 	if (default_object_context_enabled == p_enabled) {
 		return;
@@ -185,6 +185,8 @@ void OpenXRAndroidTrackablesObjectExtension::set_object_tracker_discovery_cooldo
 }
 
 void OpenXRAndroidTrackablesObjectExtension::discover_object_trackers(bool p_update_trackers, RID p_object_context) {
+	ERR_FAIL_COND(!is_trackables_object_supported() || !permissions_granted);
+
 	OpenXRAndroidTrackablesExtension *wrapper = OpenXRAndroidTrackablesExtension::get_singleton();
 	ERR_FAIL_NULL(wrapper);
 
@@ -206,6 +208,8 @@ void OpenXRAndroidTrackablesObjectExtension::discover_object_trackers(bool p_upd
 }
 
 RID OpenXRAndroidTrackablesObjectExtension::get_default_object_context() {
+	ERR_FAIL_COND_V(!is_trackables_object_supported() || !permissions_granted, RID());
+
 	OpenXRAndroidTrackablesExtension *wrapper = OpenXRAndroidTrackablesExtension::get_singleton();
 	ERR_FAIL_NULL_V(wrapper, RID());
 
@@ -218,6 +222,8 @@ RID OpenXRAndroidTrackablesObjectExtension::get_default_object_context() {
 }
 
 RID OpenXRAndroidTrackablesObjectExtension::create_object_context(Array p_object_labels) {
+	ERR_FAIL_COND_V(!is_trackables_object_supported() || !permissions_granted, RID());
+
 	LocalVector<XrObjectLabelANDROID> active_labels;
 	for (int i = 0; i < p_object_labels.size(); ++i) {
 		switch ((int)p_object_labels[i]) {
@@ -282,6 +288,7 @@ void OpenXRAndroidTrackablesObjectExtension::free_object_context(RID p_object_co
 
 void OpenXRAndroidTrackablesObjectExtension::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_trackables_object_supported"), &OpenXRAndroidTrackablesObjectExtension::is_trackables_object_supported);
+	ClassDB::bind_method(D_METHOD("are_permissions_granted"), &OpenXRAndroidTrackablesObjectExtension::are_permissions_granted);
 	ClassDB::bind_method(D_METHOD("set_default_object_context_enabled", "enabled"), &OpenXRAndroidTrackablesObjectExtension::set_default_object_context_enabled);
 	ClassDB::bind_method(D_METHOD("set_object_tracker_discovery_cooldown", "cooldown"), &OpenXRAndroidTrackablesObjectExtension::set_object_tracker_discovery_cooldown);
 	ClassDB::bind_method(D_METHOD("discover_object_trackers", "update_trackers", "object_context"), &OpenXRAndroidTrackablesObjectExtension::discover_object_trackers, DEFVAL(RID()));

--- a/plugin/src/main/cpp/include/extensions/openxr_android_device_anchor_persistence_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_android_device_anchor_persistence_extension.h
@@ -81,6 +81,7 @@ public:
 	void on_xranchor_tracker_destroyed(const StringName &p_uuid);
 
 	bool is_device_anchor_persistence_supported() const;
+	bool are_permissions_granted() const;
 
 protected:
 	static void _bind_methods();
@@ -96,7 +97,7 @@ private:
 
 	HashMap<String, bool *> request_extensions;
 	bool available = false;
-	bool check_for_permissions = false;
+	bool permissions_granted = false;
 	XrSystemDeviceAnchorPersistencePropertiesANDROID anchor_persistence_properties = {
 		XR_TYPE_SYSTEM_DEVICE_ANCHOR_PERSISTENCE_PROPERTIES_ANDROID, // type
 		nullptr, // next

--- a/plugin/src/main/cpp/include/extensions/openxr_android_raycast_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_android_raycast_extension.h
@@ -62,6 +62,7 @@ public:
 
 	TypedArray<OpenXRAndroidHitResult> raycast(Array p_trackable_types, const Vector3 &p_origin, const Vector3 &p_trajectory, int p_max_results);
 	bool is_raycast_supported() const;
+	bool are_permissions_granted() const;
 
 protected:
 	static void _bind_methods();
@@ -73,7 +74,7 @@ private:
 
 	HashMap<String, bool *> request_extensions;
 	bool available = false;
-	bool check_for_permissions = false;
+	bool permissions_granted = false;
 	Vector<TrackableType> supported_trackable_types;
 	XrTrackableTrackerANDROID depth_trackable_tracker = XR_NULL_HANDLE;
 

--- a/plugin/src/main/cpp/include/extensions/openxr_android_trackables_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_android_trackables_extension.h
@@ -88,6 +88,7 @@ public:
 
 	bool is_anchors_supported() const;
 	bool is_trackables_supported() const;
+	bool are_permissions_granted() const;
 
 	EXT_PROTO_XRRESULT_FUNC3(xrGetTrackablePlaneANDROID, (XrTrackableTrackerANDROID), trackableTracker, (const XrTrackableGetInfoANDROID *), getInfo, (XrTrackablePlaneANDROID *), planeOutput);
 	EXT_PROTO_XRRESULT_FUNC4(xrLocateSpace, (XrSpace), space, (XrSpace), baseSpace, (XrTime), time, (XrSpaceLocation *), location);
@@ -107,7 +108,7 @@ private:
 	// Init
 	HashMap<String, bool *> request_extensions;
 	bool available = false;
-	bool check_for_permissions = false;
+	bool permissions_granted = false;
 	XrSystemTrackablesPropertiesANDROID system_trackables_properties = {
 		XR_TYPE_SYSTEM_TRACKABLES_PROPERTIES_ANDROID, // type
 		nullptr, // next

--- a/plugin/src/main/cpp/include/extensions/openxr_android_trackables_object_extension.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_android_trackables_object_extension.h
@@ -58,6 +58,7 @@ public:
 	virtual void _on_session_destroyed() override;
 
 	bool is_trackables_object_supported() const;
+	bool are_permissions_granted() const;
 	void set_default_object_context_enabled(bool p_enabled);
 	void set_object_tracker_discovery_cooldown(int p_cooldown);
 	void discover_object_trackers(bool p_update_trackers, RID p_object_context = RID());
@@ -80,7 +81,7 @@ private:
 
 	HashMap<String, bool *> request_extensions;
 	bool available = false;
-	bool check_for_permissions = false;
+	bool permissions_granted = false;
 
 	int object_trackable_discovery_cooldown = 60;
 	int object_trackable_discovery_cooldown_cur = 0;

--- a/plugin/src/main/cpp/include/util.h
+++ b/plugin/src/main/cpp/include/util.h
@@ -133,4 +133,5 @@ void xrMatrix4x4f_to_godot_projection(XrMatrix4x4f *m, godot::Projection &p);
 godot::Transform3D xrPosef_to_godot_transform3d(const XrPosef &pose);
 godot::Vector3 XrVector3f_to_godot_vector3(const XrVector3f &xr_vector3);
 XrUuid string_name_to_uuid(const godot::StringName &p_uuid_str);
+bool supports_runtime_permissions();
 }; //namespace OpenXRUtilities

--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -462,6 +462,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			_register_extension_as_singleton(OpenXRAndroidEnvironmentDepthExtension::get_singleton());
 			_register_extension_as_singleton(OpenXRAndroidUnboundedReferenceSpaceExtension::get_singleton());
 			_register_extension_as_singleton(OpenXRAndroidTrackablesExtension::get_singleton());
+			_register_extension_as_singleton(OpenXRAndroidTrackablesObjectExtension::get_singleton());
 			_register_extension_as_singleton(OpenXRAndroidRaycastExtension::get_singleton());
 			_register_extension_as_singleton(OpenXRAndroidDeviceAnchorPersistenceExtension::get_singleton());
 

--- a/plugin/src/main/cpp/util.cpp
+++ b/plugin/src/main/cpp/util.cpp
@@ -32,6 +32,8 @@
 #include <openxr/internal/xr_linear.h>
 #include <openxr/openxr.h>
 #include <stdio.h>
+#include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/variant/packed_string_array.hpp>
 #include <godot_cpp/variant/projection.hpp>
 
@@ -149,4 +151,10 @@ XrUuid OpenXRUtilities::string_name_to_uuid(const StringName &p_uuid_str) {
 	}
 
 	return ret;
+}
+
+bool OpenXRUtilities::supports_runtime_permissions() {
+	OS *os = OS::get_singleton();
+	ERR_FAIL_NULL_V(os, false);
+	return os->has_feature("android");
 }

--- a/samples/androidxr-trackables-sample/anchors/menu_3d_updater.gd
+++ b/samples/androidxr-trackables-sample/anchors/menu_3d_updater.gd
@@ -40,6 +40,11 @@ func _process(_delta: float) -> void:
 
 
 # Callback from "menu3d_group"
+func are_permissions_granted() -> bool:
+	return OpenXRAndroidDeviceAnchorPersistenceExtension.are_permissions_granted()
+
+
+# Callback from "menu3d_group"
 func update_menu(menu3d: Menu3D, menu_stack_item: Menu3D.MenuStackItem):
 	if _menu3d == null || _menu2d == null:
 		_menu3d = menu3d

--- a/samples/androidxr-trackables-sample/menu_3d/menu_3d.gd
+++ b/samples/androidxr-trackables-sample/menu_3d/menu_3d.gd
@@ -1,7 +1,9 @@
 extends Node3D
 class_name Menu3D
 
+const MENU3D_BLANK = "menu3d_blank"
 const MENU3D_MAIN = "menu3d_main"
+const MENU3D_MAIN_MISSING_PERMISSIONS = "menu3d_main_missing_permissions"
 
 
 class MenuStackItem:
@@ -30,10 +32,14 @@ var _popped_backwards: bool = false
 
 func _ready() -> void:
 	_menu2d = $Viewport2Din3D.get_scene_root()
-	push_menu(MENU3D_MAIN)
 
 	_menu2d.resized.connect(_on_hud_resized)
 	_on_hud_resized()
+
+	var openxr_interface: OpenXRInterface = XRServer.find_interface("OpenXR")
+	openxr_interface.session_focussed.connect(_on_openxr_session_focused)
+
+	push_menu(MENU3D_BLANK)
 
 
 func get_menu2d() -> Menu2D:
@@ -64,12 +70,38 @@ func refresh():
 	_push_menu_impl(_menu_stack.pop_back(), true)
 
 
+func _on_openxr_session_focused() -> void:
+	for menu in get_tree().get_nodes_in_group("menu3d_group"):
+		if !menu.are_permissions_granted():
+			push_menu(MENU3D_MAIN_MISSING_PERMISSIONS)
+			return
+
+	# remove the 'missing permissions' menu if the user granted the permissions
+	if _menu_stack[_menu_stack.size() - 1].current_menu == MENU3D_MAIN_MISSING_PERMISSIONS:
+		_menu_stack.pop_back()
+
+	# only switch to the main menu if we only have MENU3D_BLANK.  Two cases:
+	#  1. this app was just launched and permissions were already granted OR
+	#  2. 'missing permissions' menu was just removed because permissions are now granted
+	if _menu_stack.size() == 1:
+		push_menu(MENU3D_MAIN)
+
+
 func _push_menu_impl(menu_stack_item: MenuStackItem, refreshed: bool):
 	_menu_stack.push_back(menu_stack_item)
 	_menu2d.clear_choices()
 
 	# keep _popped_backwards state until the current menu is not refreshed
 	_popped_backwards = _popped_backwards && refreshed
+
+	if menu_stack_item.current_menu == MENU3D_BLANK:
+		return
+
+	if menu_stack_item.current_menu == MENU3D_MAIN_MISSING_PERMISSIONS:
+		_menu2d.clear_choices()
+		_menu2d.set_title_text("Missing permissions")
+		_menu2d.add_choice("Open Settings App to grant permission(s)", _launch_android_settings_app)
+		return
 
 	if menu_stack_item.current_menu == MENU3D_MAIN:
 		_menu2d.set_title_text("Main menu")
@@ -79,3 +111,18 @@ func _push_menu_impl(menu_stack_item: MenuStackItem, refreshed: bool):
 
 func _on_hud_resized():
 	$Viewport2Din3D.set_viewport_size(_menu2d.size)
+
+
+func _launch_android_settings_app():
+	var Intent = JavaClassWrapper.wrap("android.content.Intent")
+	var Settings = JavaClassWrapper.wrap("android.provider.Settings")
+	var Uri = JavaClassWrapper.wrap("android.net.Uri")
+
+	var godot_android = Engine.get_singleton("AndroidRuntime")
+	var activity = godot_android.getActivity()
+
+	var intent = Intent.Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+	var uri = Uri.parse("package:" + activity.getPackageName())
+	intent.setData(uri)
+
+	activity.startActivity(intent)

--- a/samples/androidxr-trackables-sample/objects/objects.gd
+++ b/samples/androidxr-trackables-sample/objects/objects.gd
@@ -10,6 +10,11 @@ func _ready():
 	XRServer.tracker_removed.connect(_on_tracker_removed)
 
 
+# Callback from "menu3d_group"
+func are_permissions_granted() -> bool:
+	return OpenXRAndroidTrackablesObjectExtension.are_permissions_granted()
+
+
 func _on_tracker_added(tracker_name: StringName, _type: int):
 	var tracker: XRTracker = XRServer.get_tracker(tracker_name)
 

--- a/samples/androidxr-trackables-sample/objects/objects.tscn
+++ b/samples/androidxr-trackables-sample/objects/objects.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://beaj3v546iu0f" path="res://objects/objects.gd" id="1_o5n7m"]
 
-[node name="Objects" type="Node3D" unique_id=213923288]
+[node name="Objects" type="Node3D" unique_id=213923288 groups=["menu3d_group"]]
 script = ExtResource("1_o5n7m")

--- a/samples/androidxr-trackables-sample/planes/planes.gd
+++ b/samples/androidxr-trackables-sample/planes/planes.gd
@@ -10,6 +10,11 @@ func _ready():
 	XRServer.tracker_removed.connect(_on_tracker_removed)
 
 
+# Callback from "menu3d_group"
+func are_permissions_granted() -> bool:
+	return OpenXRAndroidTrackablesExtension.are_permissions_granted()
+
+
 func _on_tracker_added(tracker_name: StringName, _type: int):
 	var tracker: XRTracker = XRServer.get_tracker(tracker_name)
 

--- a/samples/androidxr-trackables-sample/planes/planes.tscn
+++ b/samples/androidxr-trackables-sample/planes/planes.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://cf8x6tbqmv8gw" path="res://planes/planes.gd" id="1_ig7tw"]
 
-[node name="Planes" type="Node3D" unique_id=213923288]
+[node name="Planes" type="Node3D" unique_id=213923288 groups=["menu3d_group"]]
 script = ExtResource("1_ig7tw")

--- a/samples/androidxr-trackables-sample/raycast/raycast.gd
+++ b/samples/androidxr-trackables-sample/raycast/raycast.gd
@@ -21,6 +21,11 @@ func initialize():
 
 
 # Callback from "menu3d_group"
+func are_permissions_granted() -> bool:
+	return OpenXRAndroidRaycastExtension.are_permissions_granted()
+
+
+# Callback from "menu3d_group"
 func update_menu(menu3d: Menu3D, menu_stack_item: Menu3D.MenuStackItem):
 	if menu_stack_item.current_menu != Menu3D.MENU3D_MAIN:
 		return


### PR DESCRIPTION
Addresses https://github.com/GodotVR/godot_openxr_vendors/pull/512#pullrequestreview-4724449750

Updated the permissions checks for AndroidXR Trackables (planes, objects, raycast, anchors) using the same pattern as https://github.com/GodotVR/godot_openxr_vendors/pull/512

Additionally:
* Went through each bound method to see if `ERR_FAIL_*` was needed
* Added `are_permissions_granted()` since it seemed to make sense for Trackables
* Updated and tested the sample app (androidxr-trackables-sample) to react to the current state of the permissions
* Added missing `_register_extension_as_singleton()` for `OpenXRAndroidTrackablesObjectExtension` in `register_types.cpp` (it is trivial to move this change into a separate PR if necessary)