### PR TITLE
Use 4.6 version of Godot Android Library

### DIFF
--- a/config.gradle
+++ b/config.gradle
@@ -1,24 +1,24 @@
 ext {
     versions = [
             gradlePluginVersion     : '8.6.1',
-            compileSdk              : 35,
+            compileSdk              : 36,
             minSdk                  : 24,
-            targetSdk               : 35,
+            targetSdk               : 36,
             // Update the Java version in the github workflows when this is updated.
             javaVersion             : JavaVersion.VERSION_17,
             nexusPublishVersion     : '1.3.0',
-            kotlinVersion           : '2.1.20',
+            kotlinVersion           : '2.1.21',
             // Update the NDK version in the github workflows when this is updated.
-            ndkVersion              : '28.1.13356709',
+            ndkVersion              : '29.0.14206865',
             // Note that 'plugin/src/main/AndroidManifest.xml' should be updated with content
             // from the Khronos OpenXR loader manifest.
-            openxrVersion           : '1.1.49',
+            openxrVersion           : '1.1.53',
             fragmentVersion         : '1.8.6',
             splashscreenVersion     : '1.0.1',
     ]
 
     libraries = [
-            godotAndroidLib: "org.godotengine:godot:4.5.0.stable",
+            godotAndroidLib: "org.godotengine:godot:4.6.0.stable",
     ]
 
     // Parse the release version from the gradle project properties (e.g: -Prelease_version=<version>)


### PR DESCRIPTION
We're still using the Godot 4.5 version of the Godot Android Library, even though godot_openxr_vendors v5 depends on Godot 4.6+

I noticed this because `Callable.call()` is private in the Godot 4.5 version, but public in the Godot 4.6 version, and I needed to call it :-)